### PR TITLE
The cumulative time of each TestFixture was wrong

### DIFF
--- a/DUnitX.FixtureResult.pas
+++ b/DUnitX.FixtureResult.pas
@@ -5,6 +5,7 @@ interface
 uses
   classes,
   TimeSpan,
+  Diagnostics,
   DUnitX.Generics,
   DUnitX.TestFramework,
   DUnitX.InternalInterfaces;
@@ -24,6 +25,7 @@ type
     FMemoryLeakCount   : Integer;
     FTotalCount   : integer;
 
+    FStopWatch    : TStopwatch;
     FStartTime    : TDateTime;
     FFinishTime   : TDateTime;
     FDuration     : TTimeSpan;
@@ -71,7 +73,8 @@ uses
   DateUtils,
   SysUtils;
 
-
+const
+  UNDEFINED_DATETIME = 0;
 
 { TDUnitXFixtureResult }
 
@@ -94,6 +97,8 @@ constructor TDUnitXFixtureResult.Create(const AParentResult : IFixtureResult;con
 begin
   FFixture := AFixture;
   FStartTime := Now;
+  FFinishTime := UNDEFINED_DATETIME;
+  FStopWatch := TStopwatch.StartNew;
   //Don't create collections here.. we'll lazy create;
   FChildren := nil;
   FTestResults := nil;
@@ -304,6 +309,7 @@ var
 begin
   if FChildren <> nil then
   begin
+    FDuration := TTimeSpan.Zero;
     FFinishTime := FStartTime;
     for fixture in FChildren do
     begin
@@ -314,12 +320,15 @@ begin
       Inc(FPassCount,fixture.PassCount);
       FAllPassed := FAllPassed and (not fixture.HasFailures);
       FFinishTime := Max(FFinishTime,fixture.FinishTime);
+      FDuration := FDuration.Add(fixture.Duration);
     end;
   end
-  else
+  else if (FFinishTime = UNDEFINED_DATETIME) then
+  begin
     FFinishTime := Now;
-  FDuration := TTimeSpan.FromMilliseconds(DateUtils.MilliSecondsBetween(FFinishTime,FStartTime));
-
+    FStopWatch.Stop;
+    FDuration := FStopWatch.Elapsed;
+  end;
 end;
 
 end.

--- a/DUnitX.RunResults.pas
+++ b/DUnitX.RunResults.pas
@@ -30,6 +30,7 @@ interface
 
 uses
   TimeSpan,
+  Diagnostics,
   DUnitX.TestFramework,
   DUnitX.InternalInterfaces,
   Generics.Collections,
@@ -51,6 +52,7 @@ type
     FMemoryLeakCount : Integer;
     FTotalCount : integer;
 
+    FStopWatch: TStopwatch;
     FStartTime: TDateTime;
     FFinishTime: TDateTime;
     FDuration: TTimeSpan;
@@ -91,14 +93,6 @@ implementation
 
 uses
   DateUtils,
-  {$IFDEF MSWINDOWS}
-    //TODO: Need to to remove Windows by getting a system independant performance counter.
-    {$if CompilerVersion < 23 }
-      Windows,
-    {$else}
-      WinAPI.Windows, // Delphi XE2 (CompilerVersion 23) added scopes in front of unit names
-    {$ifend}
-  {$ENDIF}
   SysUtils;
 
 { TDUnitXTestResults }
@@ -114,6 +108,7 @@ begin
   FStartTime := Now;
   FFinishTime := FStartTime;
   FDuration := TTimeSpan.Zero;
+  FStopWatch := TStopwatch.StartNew;
 end;
 
 destructor TDUnitXRunResults.Destroy;
@@ -237,13 +232,11 @@ var
 
 begin
   FFinishTime := Now;
-  FDuration := TTimeSpan.FromMilliseconds(DateUtils.MilliSecondsBetween(FFinishTime,FStartTime));
+  FDuration := FStopWatch.Elapsed;
   for fixtureResult in FFixtureResults do
     (fixtureResult as IFixtureResultBuilder).RollUpResults;
 
-  //Make sure the fixture results are unique.
-
-
+  //TODO: Make sure the fixture results are unique.
 end;
 
 function TDUnitXRunResults.ToString: string;

--- a/DUnitX.TestResult.pas
+++ b/DUnitX.TestResult.pas
@@ -77,13 +77,6 @@ type
 implementation
 
 uses
-  {$IFDEF MSWINDOWS}
-    {$if CompilerVersion < 23 }
-      Windows,
-    {$else}
-      WinAPI.Windows, // Delphi XE2 (CompilerVersion 23) added scopes in front of unit names
-    {$ifend}
-  {$ENDIF}
   DUnitX.IoC;
 
 { TDUnitXTestResult }

--- a/DUnitX.TestRunner.pas
+++ b/DUnitX.TestRunner.pas
@@ -591,8 +591,6 @@ begin
   Self.Loggers_TestingStarts(threadId, testCount, testActiveCount);
   try
     ExecuteFixtures(nil,context, threadId, fixtureList);
-    //make sure each fixture includes it's child fixture result counts.
-    context.RollupResults;
   finally
     Self.Loggers_TestingEnds(result);
   end;
@@ -652,6 +650,8 @@ begin
     finally
       Self.Loggers_EndTestFixture(threadId, fixtureResult);
     end;
+
+    context.RollupResults;
   end;
 end;
 


### PR DESCRIPTION
The cumulative time of each TestFixture was wrong, considering that should accrue only times of their children fixtures, but each TestFixture was always considering the accumulated time. 

Moreover, the timing system was replaced by TStopWatch to capture more accurate time.

PS: I do not know an appropriate way to create unit tests to this type of change, so the lack of testing in this pull request.

Before fix:
![nunit_results_before_fix](https://f.cloud.github.com/assets/842859/2241547/7c980e92-9cd7-11e3-9578-791417076e17.png)

Fixed:
![nunit_results_fixex](https://f.cloud.github.com/assets/842859/2241549/83199a56-9cd7-11e3-938d-266c87576caf.jpg)
