### PR TITLE
made Dependencies*.bat compatible with spaces in the parent directory path.

### DIFF
--- a/Dependencies-Clone.bat
+++ b/Dependencies-Clone.bat
@@ -1,3 +1,3 @@
 :: for /F "tokens=1,2 delims=-" %%t in ("%~n0") do echo %%t %%u
-for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call %~dp0%%t %%u
+for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call "%~dp0%%t" %%u
 pause

--- a/Dependencies-Pull.bat
+++ b/Dependencies-Pull.bat
@@ -1,3 +1,3 @@
 :: for /F "tokens=1,2 delims=-" %%t in ("%~n0") do echo %%t %%u
-for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call %~dp0%%t %%u
+for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call "%~dp0%%t" %%u
 pause

--- a/Dependencies-Set.bat
+++ b/Dependencies-Set.bat
@@ -1,3 +1,3 @@
 :: for /F "tokens=1,2 delims=-" %%t in ("%~n0") do echo %%t %%u
-for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call %~dp0%%t %%u
+for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call "%~dp0%%t" %%u
 pause

--- a/Dependencies-Show.bat
+++ b/Dependencies-Show.bat
@@ -1,3 +1,3 @@
 :: for /F "tokens=1,2 delims=-" %%t in ("%~n0") do echo %%t %%u
-for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call %~dp0%%t %%u
+for /F "tokens=1,2 delims=-" %%t in ("%~n0") do call "%~dp0%%t" %%u
 pause


### PR DESCRIPTION
As per report by John Kaster: the batch files would not work when there were one or more spaces in the parent directory path.

Fixed. 

Also refactored the Dependencies.bat to support:
- optional parameters in the Dependencies.txt
- dir based "repository" like reference (comes in handy when using sub-repositories)
