### PR TITLE
Possible AV in WillNotRaise if exceptionClass not assigned

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -1499,8 +1499,8 @@ begin
         if e.ClassType = exceptionClass then
            Fail('Method raised an exception of type : ' + exceptionClass.ClassName + sLineBreak + e.Message + AddLineBreak(msg), ReturnAddress)
         else
-          Fail(Format('Method raised [%s] was expecting not to raise [%s]. %s', [e.ClassName, exceptionClass.ClassName, e.message]), ReturnAddress);
-        end
+//          Fail(Format('Method raised [%s] was expecting not to raise [%s]. %s', [e.ClassName, exceptionClass.ClassName, e.message]), ReturnAddress);
+      end
       else
         Fail(Format('Method raised [%s] was expecting not to raise exception. %s', [e.ClassName, e.message]), ReturnAddress);
     end;

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -112,6 +112,8 @@ type
     procedure WillNotRaise_With_DescendingClass_Positive;
     [Test]
     procedure WillNotRaise_With_DescendingClass_Negative;
+    [Test]
+    procedure WillNotRaise_With_NoClass;
 
 
 
@@ -272,6 +274,24 @@ begin
      raise Exception.Create('Error Message');
    end,
    EStreamError,'');
+end;
+
+procedure TTestsAssert.WillNotRaise_With_NoClass;
+const
+  EXPECTED_EXCEPTION_MSG = 'Passing Message';
+begin
+ Assert.WillRaise(
+ procedure
+ begin
+   Assert.WillNotRaise(
+     procedure
+     begin
+       // Raise an exception
+       raise Exception.Create('Error Message');
+     end);
+ end,
+ ETestFailure,
+ EXPECTED_EXCEPTION_MSG);
 end;
 
 procedure TTestsAssert.WillNotRaise_With_NonDescendingClass;


### PR DESCRIPTION
if exceptionClass is not assigned the second branch would be followed, with the result of a call to - exceptionClass!
