### PR TITLE
Added XML Escaping to name attributes in NUnit output.

### DIFF
--- a/DUnitX.Loggers.XML.NUnit.pas
+++ b/DUnitX.Loggers.XML.NUnit.pas
@@ -245,6 +245,8 @@ var
   child : IFixtureResult;
   testResult : ITestResult;
   sExecuted : string;
+  sName: string;
+  sSuccess: string;
 begin
   Indent;
   try
@@ -254,6 +256,10 @@ begin
       sResult := 'Failure';
     sTime := Format('%.3f',[fixtureResult.Duration.TotalSeconds]);
 
+    sName := EscapeForXML(fixtureResult.Fixture.Name);
+    sResult := EscapeForXML(sResult);
+    sSuccess := EscapeForXML(BoolToStr(not fixtureResult.HasFailures,true));
+    sTime := EscapeForXML(sTime);
 
     //its a real fixture if the class is not TObject.
     if (not fixtureResult.Fixture.TestClass.ClassNameIs('TObject'))  then
@@ -262,8 +268,10 @@ begin
       if fixtureResult.ResultCount = 0 then
         exit;
       sExecuted := BoolToStr(fixtureResult.ResultCount > 0,true);
+      sExecuted := EscapeForXML(sExecuted);
 
-      WriteXMLLine(Format('<test-suite type="Fixture" name="%s" executed="%s" result="%s" success="%s" time="%s" >',[fixtureResult.Fixture.Name, sResult,sExecuted,BoolToStr(not fixtureResult.HasFailures,true),sTime]));
+      WriteXMLLine(Format('<test-suite type="Fixture" name="%s" executed="%s" result="%s" success="%s" time="%s" >',[sName, sResult, sExecuted, sSuccess, sTime]));
+
       Indent;
       WriteXMLLine('<results>');
       for testResult in fixtureResult.TestResults do
@@ -285,7 +293,9 @@ begin
       if fixtureResult.ChildCount = 0 then
         sLineEnd := '/';
       //It's a Namespace.
-      WriteXMLLine(Format('<test-suite type="Namespace" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0" %s>',[fixtureResult.Fixture.Name, sResult,BoolToStr(not fixtureResult.HasFailures,true),sTime,sLineEnd]));
+
+      WriteXMLLine(Format('<test-suite type="Namespace" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0" %s>',[sName, sResult, sSuccess, sTime, sLineEnd]));
+
       if fixtureResult.ChildCount > 0 then
       begin
         Indent;
@@ -326,7 +336,7 @@ var
   sTime : string;
   sExecuted : string;
   sSuccess : string;
-
+  sName : string;
 begin
   Indent;
   try
@@ -337,11 +347,16 @@ begin
     sExecuted := BoolToStr(testResult.ResultType <> TTestResultType.Ignored,true);
 
     if testResult.ResultType <> TTestResultType.Ignored then
-      sSuccess := Format('success="%s"',[BoolToStr(testResult.ResultType = TTestResultType.Pass,true)])
+      sSuccess := Format('success="%s"',[EscapeForXML(BoolToStr(testResult.ResultType = TTestResultType.Pass, true))])
     else
       sSuccess := '';
 
-    WriteXMLLine(Format('<test-case name="%s" executed="%s" result="%s" %s time="%s" asserts="0" %s>',[testResult.Test.Name, sExecuted, sResult,sSuccess,sTime,sLineEnd]));
+    sName := EscapeForXML(testResult.Test.Name);
+    sExecuted := EscapeForXML(sExecuted);
+    sResult := EscapeForXML(sResult);
+    sTime := EscapeForXML(sTime);
+
+    WriteXMLLine(Format('<test-case name="%s" executed="%s" result="%s" %s time="%s" asserts="0" %s>', [sName, sExecuted, sResult, sSuccess, sTime, sLineEnd]));
     if testResult.ResultType <> TTestResultType.Pass then
     begin
       Indent;

--- a/Examples/DUnitX.Examples.General.pas
+++ b/Examples/DUnitX.Examples.General.pas
@@ -28,9 +28,9 @@ unit DUnitX.Examples.General;
 
 {$I DUnitX.inc}
 
-{$IFDEF DELPHI_XE_UP}
-{$STRONGLINKTYPES ON}
-{$ENDIF}
+//{$IFDEF DELPHI_XE_UP}
+//{$STRONGLINKTYPES ON}
+//{$ENDIF}
 
 interface
 
@@ -60,6 +60,10 @@ type
 
     [TestCase('Case 3','Blah,1')]
     procedure AnotherTestMethod(const a : string; const b : integer);
+
+    [Test]
+    [TestCase('Case4','password="",password=""')]
+    procedure TestCaseWithStrings(const AInput : string; const AResult : string);
 
     [Test]
     procedure TestTwo;
@@ -164,7 +168,12 @@ end;
 
 procedure TMyExampleTests.AnotherTestMethod(const a: string; const b: integer);
 begin
-  TDUnitX.CurrentRunner.Status(Format('TestCaseBlah called with %s %d',[a,b]));
+  TDUnitX.CurrentRunner.Status(Format('AnotherTestMethod called with %s %d',[a,b]));
+end;
+
+procedure TMyExampleTests.TestCaseWithStrings(const AInput, AResult: string);
+begin
+  TDUnitX.CurrentRunner.Status(Format('TestCaseWithStrings called with %s %s',[AInput,AResult]));
 end;
 
 procedure TMyExampleTests.TestError;
@@ -270,10 +279,10 @@ initialization
 //manual registration for now.
 
 //Register the test fixtures
-{$IFNDEF DELPHI_XE_UP}
+//{$IFNDEF DELPHI_XE_UP}
   TDUnitX.RegisterTestFixture(TMyExampleTests);
   TDUnitX.RegisterTestFixture(TExampleFixture2);
   TDUnitX.RegisterTestFixture(TExampleFixture3);
   TDUnitX.RegisterTestFixture(TExampleFixture5);
-{$ENDIF}
+//{$ENDIF}
 end.

--- a/Examples/DUnitXExamples_XE2.dproj
+++ b/Examples/DUnitXExamples_XE2.dproj
@@ -98,7 +98,7 @@
 			<VerInfo_Locale>1033</VerInfo_Locale>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-			<Debugger_RunParams>fsdfsd</Debugger_RunParams>
+			<DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
 			<VerInfo_Locale>1033</VerInfo_Locale>
 		</PropertyGroup>
 		<ItemGroup>

--- a/Tests/DUnitXTest_XE2.dproj
+++ b/Tests/DUnitXTest_XE2.dproj
@@ -63,6 +63,7 @@
 			<DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+			<DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
 			<DCC_TypedAtParameter>true</DCC_TypedAtParameter>
 		</PropertyGroup>
 		<ItemGroup>


### PR DESCRIPTION
Added XML Escaping to all attributes written out for NUnit output. Possibly went a little overboard, but being safe for the time being. The whole unit needs to be cleaned up and tests added.

Fixes #80 

A previous commit however changed the name used, so the case is already resolved by just not writing out the parameter values. 
