### PR TITLE
Using AreSame or AreNotSame with Interfaces doesn't work always

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -1209,13 +1209,13 @@ end;
 
 class procedure Assert.AreNotSame(const left, right: IInterface; const message: string);
 begin
-  if left = right then
+  if (left as IInterface) = (right as IInterface) then
     Fail(Format('references are the same. %s',[message]), ReturnAddress);
 end;
 
 class procedure Assert.AreSame(const left, right: IInterface; const message: string);
 begin
-  if left <> right then
+  if (left as IInterface) <> (right as IInterface) then
     Fail(Format('references are Not the same. %s',[message]), ReturnAddress);
 end;
 

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -120,6 +120,11 @@ type
     [Test]
     procedure Test_Implements_Will_Pass_If_Implemented;
 
+    [Test]
+    procedure Test_AreSameOnSameObjectWithDifferentInterfaces_No_Exception;
+
+    [Test]
+    procedure Test_AreNotSameOnSameObjectWithDifferentInterfaces_Throws_Exception;
 
   end;
 
@@ -682,6 +687,31 @@ begin
   finally
     FreeAndNil(mock);
   end;
+end;
+
+
+procedure TTestsAssert.Test_AreSameOnSameObjectWithDifferentInterfaces_No_Exception;
+var
+  myObject  : IInterfaceList;
+begin
+  myObject := TInterfaceList.Create;
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.AreSame(myObject, myObject as IInterface);
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.Test_AreNotSameOnSameObjectWithDifferentInterfaces_Throws_Exception;
+var
+  myObject  : IInterfaceList;
+begin
+  myObject := TInterfaceList.Create;
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.AreNotSame(myObject, myObject as IInterface);
+    end, ETestFailure);
 end;
 
 initialization


### PR DESCRIPTION
if you compare the same objects with the type "IInterface" and the type "IInterfaceList", AreSame throws an exception.

With this fix the comparison always uses the IInterface-Pointer of the objects.
