### PR TITLE
Added Contains<T>/DoesNotContain<T> for array of T.

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -345,7 +345,9 @@ type
 {$IFDEF DELPHI_XE_UP}
     //Delphi 2010 compiler bug breaks this
     class procedure Contains<T>(const list : IEnumerable<T>; const value : T; const message : string = '');overload;
+    class procedure Contains<T>(const arr : array of T; const value : T; const message : string = '');overload;
     class procedure DoesNotContain<T>(const list : IEnumerable<T>; const value : T; const message : string = '');overload;
+    class procedure DoesNotContain<T>(const arr : array of T; const value : T; const message : string = '');overload;
 {$ENDIF}
     class procedure Implements<T : IInterface>(value : IInterface; const message : string = '' );
     class procedure IsTrue(const condition : boolean; const message : string = '');
@@ -1241,6 +1243,22 @@ begin
 
   Fail(Format('List does not contain value. %s',[message]), ReturnAddress);
 end;
+
+class procedure Assert.Contains<T>(const arr : array of T; const value : T; const message : string = '');
+var
+  o : T;
+  comparer : IComparer<T>;
+begin
+  comparer := TComparer<T>.Default;
+  for o in arr do
+  begin
+    if comparer.Compare(o,value) = 0 then
+      exit;
+  end;
+
+  Fail(Format('List does not contain value. %s',[message]), ReturnAddress);
+end;
+
 {$ENDIF}
 
 {$IFDEF DELPHI_XE_UP}
@@ -1252,6 +1270,19 @@ var
 begin
   comparer := TComparer<T>.Default;
   for o in list do
+  begin
+    if comparer.Compare(o,value) = 0 then
+      Fail(Format('List contains value. %s',[message]), ReturnAddress);
+  end;
+end;
+
+class procedure Assert.DoesNotContain<T>(const arr : array of T; const value : T; const message : string = '');
+var
+  o : T;
+  comparer : IComparer<T>;
+begin
+  comparer := TComparer<T>.Default;
+  for o in arr do
   begin
     if comparer.Compare(o,value) = 0 then
       Fail(Format('List contains value. %s',[message]), ReturnAddress);

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -126,6 +126,17 @@ type
     [Test]
     procedure Test_AreNotSameOnSameObjectWithDifferentInterfaces_Throws_Exception;
 
+    [Test]
+    procedure Contains_ArrayOfT_Throws_No_Exception_When_Value_In_Array;
+
+    [Test]
+    procedure Contains_ArrayOfT_Throws_Exception_When_Value_Not_In_Array;
+
+    [Test]
+    procedure DoesNotContain_ArrayOfT_Throws_No_Exception_When_Value_Not_In_Array;
+
+    [Test]
+    procedure DoesNotContain_ArrayOfT_Throws_Exception_When_Value_In_Array;
   end;
 
 implementation
@@ -713,6 +724,44 @@ begin
       Assert.AreNotSame(myObject, myObject as IInterface);
     end, ETestFailure);
 end;
+
+procedure TTestsAssert.Contains_ArrayOfT_Throws_No_Exception_When_Value_In_Array;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.Contains<string>(['x', 'y', 'z'], 'x');
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.Contains_ArrayOfT_Throws_Exception_When_Value_Not_In_Array;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.Contains<string>(['x', 'y', 'z'], 'a');
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.DoesNotContain_ArrayOfT_Throws_No_Exception_When_Value_Not_In_Array;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.DoesNotContain<string>(['x', 'y', 'z'], 'a');
+    end, ETestFailure);
+end;
+
+
+procedure TTestsAssert.DoesNotContain_ArrayOfT_Throws_Exception_When_Value_In_Array;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.DoesNotContain<string>(['x', 'y', 'z'], 'x');
+    end, ETestFailure);
+end;
+
 
 initialization
   TDUnitX.RegisterTestFixture(TTestsAssert);


### PR DESCRIPTION
Added Contains<T>/DoesNotContain<T> for array of T
This allows to use a statement like:
assert.Contains<string>(['a', 'b', 'c'], myItem.Name)

I don't know if it is D2010 compatible, therefore I included the code in the "IFDEF"-Clause for Delphi_XE_UP.
