### PR TITLE
IFDEF for XE around AreNotEqual was wrong

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -331,9 +331,8 @@ type
 {$IFDEF DELPHI_XE_UP}
     //Delphi 2010 compiler bug breaks this
     class procedure AreNotEqual<T>(const left, right : T; const message : string = '');overload;
-{$ELSE}
-    class procedure AreNotEqual(const left, right : Integer; const message : string = '');overload;
 {$ENDIF}
+    class procedure AreNotEqual(const left, right : Integer; const message : string = '');overload;
     class procedure AreNotEqualMemory(const left : Pointer; const right : Pointer; const size : Cardinal; const message : string = '');
 
     class procedure AreSame(const left, right : TObject; const message : string = '');overload;
@@ -1163,13 +1162,13 @@ begin
     Fail(Format('left %s equals right %s %s',[leftValue.ToString, rightValue.ToString, message]), ReturnAddress);
   end;
 end;
-{$ELSE}
+{$ENDIF}
+
 class procedure Assert.AreNotEqual(const left, right: Integer; const message: string);
 begin
   if left = right then
     Fail(Format('left %d equals right %d %s' ,[left, right, message]), ReturnAddress);
 end;
-{$ENDIF}
 
 class procedure Assert.AreNotEqual(const left, right: Extended; const message: string);
 var

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -84,6 +84,10 @@ type
     [Test]
     procedure AreEqual_Throws_No_Exception_When_Values_Are_Exactly_Equal;
     [Test]
+    procedure AreNotEqual_Integer_Throws_No_Exception_When_Values_Are_NotEqual;
+    [Test]
+    procedure AreNotEqual_Integer_Throws_Exception_When_Values_Are_Equal;
+    [Test]
     procedure WillRaise_Without_Exception_Class_Will_Capture_Any_Exception;
     [Test]
     procedure WillRaiseWithMessage_Exception_And_Message_Will_Check_ExceptionClass_And_Exception_Message;
@@ -711,6 +715,24 @@ begin
     procedure
     begin
       Assert.AreNotSame(myObject, myObject as IInterface);
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.AreNotEqual_Integer_Throws_No_Exception_When_Values_Are_NotEqual;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.AreNotEqual(1, 2);
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.AreNotEqual_Integer_Throws_Exception_When_Values_Are_Equal;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.AreNotEqual(1, 1);
     end, ETestFailure);
 end;
 


### PR DESCRIPTION
The IfDef-Declaration around "AreNotEqual(integer)" was wrong. 
Therefore this method was unavailable from Delphi XE upwards.
