### PR TITLE
Added Contains<T>/DoesNotContain<T> for array of T.

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -344,7 +344,9 @@ type
 {$IFDEF DELPHI_XE_UP}
     //Delphi 2010 compiler bug breaks this
     class procedure Contains<T>(const list : IEnumerable<T>; const value : T; const message : string = '');overload;
+    class procedure Contains<T>(const arr : array of T; const value : T; const message : string = '');overload;
     class procedure DoesNotContain<T>(const list : IEnumerable<T>; const value : T; const message : string = '');overload;
+    class procedure DoesNotContain<T>(const arr : array of T; const value : T; const message : string = '');overload;
 {$ENDIF}
     class procedure Implements<T : IInterface>(value : IInterface; const message : string = '' );
     class procedure IsTrue(const condition : boolean; const message : string = '');
@@ -1240,6 +1242,22 @@ begin
 
   Fail(Format('List does not contain value. %s',[message]), ReturnAddress);
 end;
+
+class procedure Assert.Contains<T>(const arr : array of T; const value : T; const message : string = '');
+var
+  o : T;
+  comparer : IComparer<T>;
+begin
+  comparer := TComparer<T>.Default;
+  for o in arr do
+  begin
+    if comparer.Compare(o,value) = 0 then
+      exit;
+  end;
+
+  Fail(Format('List does not contain value. %s',[message]), ReturnAddress);
+end;
+
 {$ENDIF}
 
 {$IFDEF DELPHI_XE_UP}
@@ -1251,6 +1269,19 @@ var
 begin
   comparer := TComparer<T>.Default;
   for o in list do
+  begin
+    if comparer.Compare(o,value) = 0 then
+      Fail(Format('List contains value. %s',[message]), ReturnAddress);
+  end;
+end;
+
+class procedure Assert.DoesNotContain<T>(const arr : array of T; const value : T; const message : string = '');
+var
+  o : T;
+  comparer : IComparer<T>;
+begin
+  comparer := TComparer<T>.Default;
+  for o in arr do
   begin
     if comparer.Compare(o,value) = 0 then
       Fail(Format('List contains value. %s',[message]), ReturnAddress);

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -130,6 +130,17 @@ type
     [Test]
     procedure Test_AreNotSameOnSameObjectWithDifferentInterfaces_Throws_Exception;
 
+    [Test]
+    procedure Contains_ArrayOfT_Throws_No_Exception_When_Value_In_Array;
+
+    [Test]
+    procedure Contains_ArrayOfT_Throws_Exception_When_Value_Not_In_Array;
+
+    [Test]
+    procedure DoesNotContain_ArrayOfT_Throws_No_Exception_When_Value_Not_In_Array;
+
+    [Test]
+    procedure DoesNotContain_ArrayOfT_Throws_Exception_When_Value_In_Array;
   end;
 
 implementation
@@ -733,6 +744,43 @@ begin
     procedure
     begin
       Assert.AreNotEqual(1, 1);
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.Contains_ArrayOfT_Throws_No_Exception_When_Value_In_Array;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.Contains<string>(['x', 'y', 'z'], 'x');
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.Contains_ArrayOfT_Throws_Exception_When_Value_Not_In_Array;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.Contains<string>(['x', 'y', 'z'], 'a');
+    end, ETestFailure);
+end;
+
+procedure TTestsAssert.DoesNotContain_ArrayOfT_Throws_No_Exception_When_Value_Not_In_Array;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      Assert.DoesNotContain<string>(['x', 'y', 'z'], 'a');
+    end, ETestFailure);
+end;
+
+
+procedure TTestsAssert.DoesNotContain_ArrayOfT_Throws_Exception_When_Value_In_Array;
+begin
+  Assert.WillRaise(
+    procedure
+    begin
+      Assert.DoesNotContain<string>(['x', 'y', 'z'], 'x');
     end, ETestFailure);
 end;
 


### PR DESCRIPTION
Added Contains/DoesNotContain for array of T
This allows to use a statement like:
assert.Contains(['a', 'b', 'c'], myItem.Name)

I don't know if it is D2010 compatible, therefore I included the code in the "IFDEF"-Clause for Delphi_XE_UP.
