### PR TITLE
Initial implementation of MaxTimeAttribute for tests

### DIFF
--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -60,6 +60,10 @@ type
     function GetIgnoreReason : string;
     function GetIgnoreMemoryLeaks() : Boolean;
     procedure SetIgnoreMemoryLeaks(const AValue : Boolean);
+    function GetMaxTime: cardinal;
+    procedure SetMaxTime(const AValue: cardinal);
+    function GetTimedOut: Boolean;
+    procedure SetTimedOut(const AValue: Boolean);
 
     property Name : string read GetName;
     property FullName : string read GetFullName;
@@ -70,6 +74,8 @@ type
     property IgnoreReason : string read GetIgnoreReason;
     property TestMethod : TTestMethod read GetTestMethod;
     property IgnoreMemoryLeaks : Boolean read GetIgnoreMemoryLeaks write SetIgnoreMemoryLeaks;
+    property MaxTime: cardinal read GetMaxTime write SetMaxTime;
+    property TimedOut: Boolean read GetTimedOut write SetTimedOut;
   end;
 
   ITestList = interface(IList<ITest>)
@@ -112,7 +118,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = '') : ITest;
+    function AddTest(const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const ATimeOut : cardinal = 0) : ITest;
     function AddTestCase(const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -247,10 +247,12 @@ var
   testEnabled     : boolean;
   isTestMethod    : boolean;
   repeatAttrib    : RepeatTestAttribute;
+  maxTimeAttrib   : MaxTimeAttribute;
 
   category        : string;
   ignoredTest     : boolean;
   ignoredReason   : string;
+  maxTime         : cardinal;
 
   repeatCount: Cardinal;
   i: Integer;
@@ -296,6 +298,8 @@ begin
     categoryAttrib := nil;
     isTestMethod := false;
     repeatCount := 1;
+    maxTimeAttrib := nil;
+    maxTime := 0;
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;
@@ -367,15 +371,18 @@ begin
 
     if method.TryGetAttributeOfType<IgnoreAttribute>(ignoredAttrib) then
     begin
-       ignoredTest   := true;
-       ignoredReason := ignoredAttrib.Reason;
+      ignoredTest   := true;
+      ignoredReason := ignoredAttrib.Reason;
     end;
 
     if method.TryGetAttributeOfType<TestAttribute>(testAttrib) then
     begin
-       testEnabled := testAttrib.Enabled;
-       isTestMethod := true;
+      testEnabled := testAttrib.Enabled;
+      isTestMethod := true;
     end;
+
+    if method.TryGetAttributeOfType<MaxTimeAttribute>(maxTimeAttrib) then
+      maxTime := maxTimeAttrib.MaxTime;
 
     if method.IsDestructor or method.IsConstructor then
       continue;
@@ -415,7 +422,7 @@ begin
         else
         begin
           //if a testcase is ignored, just add it as a regular test.
-          currentFixture.AddTest(TTestMethod(meth),method.Name,category,true,true,ignoredReason);
+          currentFixture.AddTest(TTestMethod(meth),method.Name,category,true,true,ignoredReason,maxTime);
         end;
         continue;
       end;
@@ -425,7 +432,7 @@ begin
     begin
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason);
+        currentFixture.AddTest(TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason,maxTime);
       end;
       continue;
     end;
@@ -436,7 +443,7 @@ begin
       // Add Published Method that has no Attributes
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason);
+        currentFixture.AddTest(TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason,maxTime);
       end;
     end;
   end;

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -111,7 +111,7 @@ type
 
     procedure ExecuteFixtureTearDown;
 
-    function AddTest(const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = '') : ITest;
+    function AddTest(const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime : cardinal = 0) : ITest;
     function AddTestCase(const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -495,9 +495,9 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string): ITest;
+function TDUnitXTestFixture.AddTest(const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime : cardinal): ITest;
 begin
-  result  := TDUnitXTest.Create(Self, AName, ACategory, AMethod,AEnabled,AIgnored,AIgnoreReason);
+  result  := TDUnitXTest.Create(Self, AName, ACategory, AMethod,AEnabled,AIgnored,AIgnoreReason,AMaxTime);
   FTests.Add(Result);
 end;
 

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -186,6 +186,21 @@ type
     property Count : Cardinal read FCount;
   end;
 
+  ///	<summary>
+  ///	  Marks a test method to fail after the time specified.
+  ///	</summary>
+  ///	<remarks>
+  ///	  If [MaxTime(1000]] used then the test will fail if the
+  ///   test takes longer than 1000ms
+  ///	</remarks>
+  MaxTimeAttribute = class(TCustomAttribute)
+  private
+    FMaxTime : Cardinal;
+  public
+    constructor Create(const AMaxTime : Cardinal);
+    property MaxTime : Cardinal read FMaxTime;
+  end;
+
   TValueArray = DUnitX.Extensibility.TValueArray;
 
 
@@ -2025,6 +2040,13 @@ end;
 constructor RepeatTestAttribute.Create(const ACount: Cardinal);
 begin
   FCount := ACount;
+end;
+
+{ MaxTimeAttribute }
+
+constructor MaxTimeAttribute.Create(const AMaxTime : Cardinal);
+begin
+  FMaxTime := AMaxTime;
 end;
 
 { IgnoreAttribute }

--- a/DUnitX.Utils.pas
+++ b/DUnitX.Utils.pas
@@ -727,6 +727,16 @@ function Supports(const Instance: TValue; const IID: TGUID; out Intf): Boolean; 
 const
   ObjCastGUID: TGUID = '{CEDF24DE-80A4-447D-8C75-EB871DC121FD}';
 
+type
+  ETimeOutException = class(Exception);
+
+  ITimeout = interface(IUnknown)
+    ['{0A380F7B-9CEE-4FD7-9D86-60CE05B97C1A}']
+    procedure Stop;
+  end;
+
+  function InitialiseTimeout(const ATime: cardinal): ITimeout;
+
 implementation
 
 uses
@@ -734,7 +744,8 @@ uses
   Generics.Defaults,
   Math,
   StrUtils,
-  SysConst;
+  SysConst,
+  Windows;
 
 var
   Context: TRttiContext;
@@ -3133,6 +3144,115 @@ begin
   for i := 0 to values.Count - 1 do
     result[i] := values[i];
 end;
+
+
+// Timeout code
+// The following code allows a timeout to be set
+
+//try
+//  InitialiseTimeOut(4000); // set a 4 second timeout
+
+//  DoSomeOperations;
+//except
+//  On E: ETimeOutException do
+//    ShowMessage( 'Operation Timed Out' );
+//end;
+
+// The following TimeOut code is based on the code found at
+// https://code.google.com/p/delphitimeouts/
+// DelphiTimeouts version 1.1
+// Copyright (c) 2007-2008 Szymon Jachim
+
+type
+  TTimeoutThread = class(TThread)
+  private
+    procedure TimeoutThread;
+  public
+    ThreadHandle: Cardinal;
+    Timeout: Cardinal;
+    procedure Execute; override;
+  end;
+
+  TTimeout = class(TInterfacedObject, ITimeout)
+  private
+    FTimeoutThread: TTimeoutThread;
+  public
+    constructor Create(const ATimeout: Cardinal; AThreadHandle: THandle);
+    destructor Destroy; override;
+
+    procedure Stop;
+  end;
+
+function InitialiseTimeout(const ATime: cardinal): ITimeout;
+var
+  ThisThreadHandle: THandle;
+begin
+  DuplicateHandle(GetCurrentProcess, GetCurrentThread, GetCurrentProcess, @ThisThreadHandle, 0, True, DUPLICATE_SAME_ACCESS);
+  Result := TTimeout.Create(ATime, ThisThreadHandle);
+end;
+
+procedure RaiseTimeOutException;
+begin
+  raise ETimeoutException.Create('Operation Timed Out');
+end;
+
+procedure TTimeoutThread.TimeoutThread;
+var
+  Ctx: _CONTEXT;
+begin
+  SuspendThread(ThreadHandle);
+  Ctx.ContextFlags := CONTEXT_FULL;
+  GetThreadContext(ThreadHandle, Ctx);
+  Ctx.Eip := Cardinal(@RaiseTimeOutException);
+  SetThreadContext(ThreadHandle, Ctx);
+  ResumeThread(ThreadHandle);
+end;
+
+{ TTimeout }
+
+procedure TTimeout.Stop;
+begin
+  FTimeoutThread.Terminate;
+end;
+
+constructor TTimeout.Create(const ATimeout: Cardinal; AThreadHandle: THandle);
+begin
+  FTimeoutThread := TTimeoutThread.Create(true);
+  FTimeoutThread.FreeOnTerminate := true;
+  FTimeoutThread.ThreadHandle := AThreadHandle;
+  FTimeoutThread.Timeout := ATimeout;
+  FTimeoutThread.Resume;
+end;
+
+destructor TTimeout.Destroy;
+begin
+  Stop;  // unwinding and we need to stop the thread, as it may still raise an exception
+  inherited;
+end;
+
+{ TTimeoutThread }
+
+procedure TTimeoutThread.Execute;
+var
+  I: Integer;
+begin
+  inherited;
+
+  for I := Timeout downto 0 do
+  begin
+    Sleep(1);
+    if Terminated then
+      Break;
+  end;
+
+  if not Terminated then
+    TimeoutThread;
+end;
+
+
+
+
+
 
 initialization
   Enumerations := TObjectDictionary<PTypeInfo, TStrings>.Create([doOwnsValues]);

--- a/Tests/DUnitX.Tests.TestFixture.pas
+++ b/Tests/DUnitX.Tests.TestFixture.pas
@@ -99,6 +99,25 @@ type
   end;
   {$M-}
 
+  {$M+}
+  [TestFixture]
+  TTestMaxTimeAttribute = class
+  public
+    [Test]
+    [MaxTime(0)]
+    procedure MaxTimeIsZero;
+
+
+    [Test]
+    [MaxTime(100)]
+    procedure TestTimeout;
+
+    [Test]
+    [MaxTime(100)]
+    procedure TestDoesNotTimeout;
+  end;
+  {$M-}
+
 implementation
 
 uses
@@ -192,9 +211,31 @@ begin
   Assert.AreEqual(TIMES_RUN_TEST_CASE, _TimesRunTestCase, 'TimesRunTestCase');
 end;
 
+{ TTestMaxTimeAttribute }
+
+procedure TTestMaxTimeAttribute.MaxTimeIsZero;
+begin
+  Sleep( 100 );
+  Assert.Pass;  // even after a delay,
+                // the test should not timeout, as zero means no timeout
+end;
+
+procedure TTestMaxTimeAttribute.TestTimeout;
+begin
+  Sleep( 150 );
+  Assert.Fail;  // the test should time out before this point
+end;
+
+procedure TTestMaxTimeAttribute.TestDoesNotTimeout;
+begin
+  Assert.Pass;  // the test should NOT time out before this point
+end;
+
+
 initialization
   TDUnitX.RegisterTestFixture(TTestClassWithNonPublicSetup);
   TDUnitX.RegisterTestFixture(TTestClassWithTestSource);
   TDUnitX.RegisterTestFixture(TTestRepeatAttribute);
+  TDUnitX.RegisterTestFixture(TTestMaxTimeAttribute);
 
 end.


### PR DESCRIPTION
This is supported in AddTest, but not AddTestCase. See the unit tests for TTestMaxTimeAttribute for what is supported.