### PR TITLE
Quite some refactoring on the container

### DIFF
--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -219,12 +219,9 @@ var
   childFixture : ITestFixture;
 
   rType : TRttiType;
-  rBaseType : TRttiType;
   methods : TArray<TRttiMethod>;
   method : TRttiMethod;
-  attribute : TCustomAttribute;
   meth : TMethod;
-  fixtureAttrib   : TestFixtureAttribute;
 
   tearDownFixtureIsDestructor : boolean;
   setupMethod : TTestMethod;

--- a/DUnitX.IoC.pas
+++ b/DUnitX.IoC.pas
@@ -168,7 +168,7 @@ end;
 
 function TDUnitXIoC.HasService<T>: boolean;
 begin
-  result := Self.Resolve<T> <> nil;
+  Result := FContainerInfo.ContainsKey(GetInterfaceKey<T>);
 end;
 
 {$IFDEF DELPHI_XE_UP}

--- a/DUnitX.IoC.pas
+++ b/DUnitX.IoC.pas
@@ -211,8 +211,7 @@ end;
 
 class destructor TDUnitXIoC.ClassDestroy;
 begin
-  if FDefault <> nil then
-    FDefault.Free;
+  FDefault.Free;
 end;
 
 procedure TDUnitXIoC.Clear;

--- a/DUnitX.MemoryLeakMonitor.Default.pas
+++ b/DUnitX.MemoryLeakMonitor.Default.pas
@@ -61,11 +61,7 @@ uses
 
 procedure RegisterDefaultProvider;
 begin
-  TDUnitXIoC.DefaultContainer.RegisterType<IMemoryLeakMonitor>(
-    function : IMemoryLeakMonitor
-    begin
-      result := TDUnitXDefaultMemoryLeakMonitor.Create;
-    end);
+  TDUnitXIoC.DefaultContainer.RegisterType<IMemoryLeakMonitor, TDUnitXDefaultMemoryLeakMonitor>;
 end;
 
 

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -370,54 +370,54 @@ type
     ///	</summary>
     procedure OnTestFailure(const threadId : Cardinal;const  Failure: ITestError);
 
-    ///	<summary>
-    ///	  //called when a test is ignored.
-    ///	</summary>
+    /// <summary>
+    ///   called when a test is ignored.
+    /// </summary>
     procedure OnTestIgnored(const threadId : Cardinal; const AIgnored: ITestResult);
 
-    ///	<summary>
-    ///	  //called when a test memory leaks.
-    ///	</summary>
+    /// <summary>
+    ///   called when a test memory leaks.
+    /// </summary>
     procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
 
-    ///	<summary>
-    ///	  //allows tests to write to the log.
-    ///	</summary>
+    /// <summary>
+    ///   allows tests to write to the log.
+    /// </summary>
     procedure OnLog(const logType : TLogLevel; const msg : string);
 
-    ///	<summary>
-    ///	  //called before a Test Teardown method is run.
-    ///	</summary>
+    /// <summary>
+    ///   called before a Test Teardown method is run.
+    /// </summary>
     procedure OnTeardownTest(const threadId : Cardinal;const  Test: ITestInfo);
 
-    ///	<summary>
-    ///	  //called after a test teardown method is run.
-    ///	</summary>
+    /// <summary>
+    ///   called after a test teardown method is run.
+    /// </summary>
     procedure OnEndTeardownTest(const threadId : Cardinal; const Test: ITestInfo);
 
-    ///	<summary>
-    ///	  //called after a test method and teardown is run.
-    ///	</summary>
+    /// <summary>
+    ///   called after a test method and teardown is run.
+    /// </summary>
     procedure OnEndTest(const threadId : Cardinal;const  Test: ITestResult);
 
-    ///	<summary>
-    ///	  //called before a Fixture Teardown method is called.
-    ///	</summary>
+    /// <summary>
+    ///   called before a Fixture Teardown method is called.
+    /// </summary>
     procedure OnTearDownFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
 
-    ///	<summary>
-    ///	  //called after a Fixture Teardown method is called.
-    ///	</summary>
+    /// <summary>
+    ///   called after a Fixture Teardown method is called.
+    /// </summary>
     procedure OnEndTearDownFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
 
-    ///	<summary>
-    ///	  //called after a Fixture has run.
-    ///	</summary>
+    /// <summary>
+    ///   called after a Fixture has run.
+    /// </summary>
     procedure OnEndTestFixture(const threadId : Cardinal; const results : IFixtureResult);
 
-    ///	<summary>
-    ///	  //called after all fixtures have run.
-    ///	</summary>
+    /// <summary>
+    ///   called after all fixtures have run.
+    /// </summary>
     procedure OnTestingEnds(const RunResults: IRunResults);
   end;
 
@@ -474,7 +474,7 @@ type
     property XMLOutputFile : string read FXMLOutputFile write FXMLOutputFile;
 
     // Specifiy the tests to run.
-    property Run : TStringList read FRun write FRun;
+    property Run : TStringList read FRun;
 
     //the name of a file which lists the tests to run.
     property RunListFile : string read FRunListFile write FRunListFile;
@@ -515,6 +515,7 @@ type
   public
     class function CreateRunner : ITestRunner;overload;
     class function CreateRunner(const ALogger : ITestLogger) : ITestRunner;overload;
+    class function CreateRunner(const ALoggers : array of ITestLogger) : ITestRunner;overload;
     class procedure RegisterTestFixture(const AClass : TClass; const AName : string = '' );
     class procedure RegisterPlugin(const plugin : IPlugin);
     class function CurrentRunner : ITestRunner;
@@ -594,11 +595,18 @@ uses
 
 constructor TDUnitXOptions.Create;
 begin
-  Run := TStringList.Create;
-  LogLevel := TLogLevel.Information;
-  ExitBehavior := TDUnitXExitBehavior.Pause;
+  FRun := TStringList.Create;
+  FLogLevel := TLogLevel.Information;
+  FExitBehavior := TDUnitXExitBehavior.Pause;
 end;
 
+destructor TDUnitXOptions.Destroy;
+begin
+  FRun.Free;
+  inherited;
+end;
+
+{ TDUnitX }
 
 class function TDUnitX.CreateRunner: ITestRunner;
 begin
@@ -610,6 +618,11 @@ begin
   result := TDUnitXTestRunner.Create(ALogger);
 end;
 
+class function TDUnitX.CreateRunner(
+  const ALoggers: array of ITestLogger): ITestRunner;
+begin
+  Result := TDUnitXTestRunner.Create(ALoggers);
+end;
 
 procedure WriteLine(consoleWriter : IDUnitXConsoleWriter; const value : string);
 begin
@@ -754,12 +767,6 @@ begin
 
   if not RegisteredFixtures.ContainsKey(AClass) then
       RegisteredFixtures.Add(AClass,sName );
-end;
-
-destructor TDUnitXOptions.Destroy;
-begin
-  FRun.Free;
-  inherited;
 end;
 
 

--- a/DUnitX.TestRunner.pas
+++ b/DUnitX.TestRunner.pas
@@ -136,7 +136,9 @@ type
     class constructor Create;
     class destructor Destroy;
   public
-    constructor Create(const AListener : ITestLogger);
+    constructor Create; overload;
+    constructor Create(const AListener : ITestLogger); overload;
+    constructor Create(const AListeners : array of ITestLogger); overload;
     destructor Destroy;override;
     class function GetActiveRunner : ITestRunner;
   end;
@@ -292,21 +294,33 @@ begin
   end;
 end;
 
-constructor TDUnitXTestRunner.Create(const AListener: ITestLogger);
+constructor TDUnitXTestRunner.Create;
 begin
   FLoggers := TList<ITestLogger>.Create;
-  if AListener <> nil then
-    FLoggers.Add(AListener);
   FFixtureClasses := TDictionary<TClass,string>.Create;
-
   FUseRTTI := False;
-  FLogMessages    := TStringList.Create;
+  FLogMessages := TStringList.Create;
   MonitorEnter(TDUnitXTestRunner.FActiveRunners);
   try
     TDUnitXTestRunner.FActiveRunners.Add(TThread.CurrentThread.ThreadID, TWeakReference<ITestRunner>.Create(Self));
   finally
     MonitorExit(TDUnitXTestRunner.FActiveRunners);
   end;
+end;
+
+constructor TDUnitXTestRunner.Create(const AListener: ITestLogger);
+begin
+  Create;
+
+  if AListener <> nil then
+    FLoggers.Add(AListener);
+end;
+
+constructor TDUnitXTestRunner.Create(const AListeners: array of ITestLogger);
+begin
+  Create;
+
+  FLoggers.AddRange(AListeners);
 end;
 
 function TDUnitXTestRunner.CreateFixture(const AInstance : TObject;const AFixtureClass: TClass; const AName: string; const ACategory : string): ITestFixture;

--- a/Tests/DUnitX.Tests.TestNameParser.pas
+++ b/Tests/DUnitX.Tests.TestNameParser.pas
@@ -41,7 +41,7 @@ var
   names : TArray<string>;
 begin
   names := TTestNameParser.Parse(name);
-  Assert.AreEqual(1,Length(names));
+  Assert.AreEqual(1,Integer(Length(names)));
   Assert.AreEqual(Trim(name), names[0]);
 end;
 
@@ -50,7 +50,7 @@ var
   names : TArray<string>;
 begin
   names := TTestNameParser.Parse(name1 + ',' + name2);
-  Assert.AreEqual(2, Length(names));
+  Assert.AreEqual(2, Integer(Length(names)));
   Assert.AreEqual(Trim(name1), names[0]);
   Assert.AreEqual(Trim(name2), names[1]);
 end;


### PR DESCRIPTION
Made many methods non generic as they are just working with interfaces which can be handled as IInterface.
Also made sure that the delegate already returns the proper type so any further QueryInterface calls are unnecessary.

Used a trick to improve instance creation by taking the codeaddress of the rtti method and casting it to the ctor signature for faster invokation.

Made use of the memoize pattern for capturing the constructor so it only gets queried by rtti once.
Used the same pattern for making sure that a singleton is only created once without any additional checks outside the delegate.