### PR TITLE
added support for extended leak monitors that support memory allocation report

### DIFF
--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -565,6 +565,11 @@ type
     function TestMemoryAllocated: Int64;
   end;
 
+  IMemoryLeakMonitor2 = interface(IMemoryLeakMonitor)
+  ['{33559983-D522-4ED5-9B5E-AC9A055FA01A}']
+    function GetReport: string;
+  end;
+
 
   ETestFrameworkException = class(Exception);
 

--- a/DUnitX.TestRunner.pas
+++ b/DUnitX.TestRunner.pas
@@ -266,6 +266,8 @@ var
   LSetUpMemoryAllocated: Int64;
   LTearDownMemoryAllocated: Int64;
   LTestMemoryAllocated: Int64;
+  LMsg: string;
+  LMemoryAllocationProvider2: IMemoryLeakMonitor2;
 begin
   Result := True;
   errorResult := nil;
@@ -280,23 +282,29 @@ begin
   if (LSetUpMemoryAllocated + LTestMemoryAllocated + LTearDownMemoryAllocated = 0) then
     Exit(True);
 
+  if memoryAllocationProvider.QueryInterface(IMemoryLeakMonitor2, LMemoryAllocationProvider2) = 0 then
+    LMsg := LMemoryAllocationProvider2.GetReport;
+
   if (LTestMemoryAllocated = 0) then
   begin
     // The leak occurred in the setup/teardown
     Result := False;
-    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, Format('%d bytes were leaked in the setup/teardown methods', [LSetUpMemoryAllocated + LTearDownMemoryAllocated]));
+    LMsg := Format('%d bytes were leaked in the setup/teardown methods', [LSetUpMemoryAllocated + LTearDownMemoryAllocated]) + LMsg;
+    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, LMsg);
   end
   else if (LSetUpMemoryAllocated + LTearDownMemoryAllocated = 0) then
   begin
     // The leak occurred in the test only
     Result := False;
-    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, Format('%d bytes were leaked in the test method', [LTestMemoryAllocated]));
+    LMsg := Format('%d bytes were leaked in the test method', [LTestMemoryAllocated]) + LMsg;
+    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, LMsg);
   end
   else
   begin
     // The leak occurred in the setup/teardown/test
     Result := False;
-    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, Format('%d bytes were leaked in the setup/test/teardown methods', [LSetUpMemoryAllocated + LTestMemoryAllocated + LTearDownMemoryAllocated]));
+    LMsg := Format('%d bytes were leaked in the setup/test/teardown methods', [LSetUpMemoryAllocated + LTestMemoryAllocated + LTearDownMemoryAllocated]) + LMsg;
+    errorResult := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.MemoryLeak, LMsg);
   end;
 end;
 


### PR DESCRIPTION
This patch should leave all existing use cases intact while extending the interface reasonably enough so that leak monitors that support textual memory report may take advantage of that.