### PR TITLE
Workaround the Delphi XE3 Compiler Bug

### DIFF
--- a/DUnitX.Init.pas
+++ b/DUnitX.Init.pas
@@ -1,0 +1,19 @@
+unit DUnitX.Init;
+
+interface
+
+uses DUnitX.TestFramework, DUnitX.FixtureProviderPlugin;
+
+implementation
+
+procedure InitAssert;
+begin
+  DUnitX.TestFramework.Assert.TestFailure := ETestFailure;
+  DUnitX.TestFramework.Assert.TestPass := ETestPass;
+end;
+
+initialization
+ TDUnitX.RegisterPlugin(TDUnitXFixtureProviderPlugin.Create);
+ InitAssert;
+
+end.

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -866,10 +866,12 @@ begin
   Assert.TestPass := ETestPass;
 end;
 
+{$IFNDEF DELPHI_XE3}
 initialization
   TDUnitX.RegisterPlugin(TDUnitXFixtureProviderPlugin.Create);
   InitAssert;
 
 finalization
+{$ENDIF}
 
 end.

--- a/Examples/DUnitXExamples_XE3.dpr
+++ b/Examples/DUnitXExamples_XE3.dpr
@@ -40,7 +40,8 @@ uses
   DUnitX.CommandLine.Parser in '..\DUnitX.CommandLine.Parser.pas',
   DUnitX.OptionsDefinition in '..\DUnitX.OptionsDefinition.pas',
   DUnitX.Banner in '..\DUnitX.Banner.pas',
-  DUnitX.Filters in '..\DUnitX.Filters.pas';
+  DUnitX.Filters in '..\DUnitX.Filters.pas',
+  DUnitX.Init in '..\DUnitX.Init.pas';
 
 var
   runner : ITestRunner;

--- a/Examples/DUnitXExamples_XE3.dproj
+++ b/Examples/DUnitXExamples_XE3.dproj
@@ -158,6 +158,7 @@
 	<DCCReference Include="..\DUnitX.OptionsDefinition.pas"/>
 	<DCCReference Include="..\DUnitX.Banner.pas"/>
 	<DCCReference Include="..\DUnitX.Filters.pas"/>
+	<DCCReference Include="..\DUnitX.Init.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This is far from a complete list, but a few planned features are listed here to 
  * Remote logging - Simple way to run tests on remote machines (just an idea at this point) 
  * Data driven test cases - the ability to provide a test method with a data source and test each entry in the data source. The data source will be virtualised so it can be anything (text file, db table etc).
 
+Tips and Tricks
+===========
+* In order to workaround the [Delphi XE3 Bug](https://github.com/VSoftTechnologies/DUnitX/issues/117), you need to add the unit DUnitX.Init to your test projects.
 
 Support
 =======

--- a/Tests/DUnitXTest_XE3.dpr
+++ b/Tests/DUnitXTest_XE3.dpr
@@ -62,7 +62,8 @@ uses
   DUnitX.Tests.Inheritance in 'DUnitX.Tests.Inheritance.pas',
   DUnitX.Tests.ConsoleWriter.Base in 'DUnitX.Tests.ConsoleWriter.Base.pas',
   DUnitX.Assert in '..\DUnitX.Assert.pas',
-  DUnitX.Types in '..\DUnitX.Types.pas';
+  DUnitX.Types in '..\DUnitX.Types.pas',
+  DUnitX.Init in '..\DUnitX.Init.pas';
 
 var
   runner : ITestRunner;

--- a/Tests/DUnitXTest_XE3.dproj
+++ b/Tests/DUnitXTest_XE3.dproj
@@ -138,6 +138,7 @@
         <DCCReference Include="DUnitX.Tests.ConsoleWriter.Base.pas"/>
         <DCCReference Include="..\DUnitX.Assert.pas"/>
         <DCCReference Include="..\DUnitX.Types.pas"/>
+        <DCCReference Include="..\DUnitX.Init.pas"/>
         <None Include="..\DUnitX.inc"/>
         <None Include="..\DUnitX.Stacktrace.inc"/>
         <None Include="..\DUnitX.MemoryLeaks.inc"/>


### PR DESCRIPTION
Putting the initialization section into a third unit (DUnitX,Init) seems to solve the problem. 
The extra unit needs to be added only for XE3 projects.
This ~~workaround~~ fixes #117.