### PR TITLE
Implemented the Max Timeout attribute for tests.

### DIFF
--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -112,6 +112,21 @@ type
     property IgnoreMemoryLeaks : Boolean read FIgnoreMemoryLeaks;
   end;
 
+  ///	<summary>
+  ///	  Marks a test method to fail after the time specified.
+  ///	</summary>
+  ///	<remarks>
+  ///	  If [MaxTime(1000]] used then the test will fail if the
+  ///   test takes longer than 1000ms
+  ///	</remarks>
+  MaxTimeAttribute = class(TCustomAttribute)
+  private
+    FMaxTime : Cardinal;
+  public
+    constructor Create(const AMaxTime : Cardinal);
+    property MaxTime : Cardinal read FMaxTime;
+  end;
+
   /// <summary>
   ///   This attribute marks a method as a test method
   /// </summary>
@@ -333,6 +348,13 @@ end;
 function TestCaseAttribute.GetValues: TValueArray;
 begin
   Result := FCaseInfo.Values;
+end;
+
+{ MaxTimeAttribute }
+
+constructor MaxTimeAttribute.Create(const AMaxTime : Cardinal);
+begin
+  FMaxTime := AMaxTime;
 end;
 
 end.

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -62,6 +62,10 @@ type
     function GetIgnoreReason : string;
     function GetIgnoreMemoryLeaks() : Boolean;
     procedure SetIgnoreMemoryLeaks(const AValue : Boolean);
+    function GetMaxTime: cardinal;
+    procedure SetMaxTime(const AValue: cardinal);
+    function GetTimedOut: Boolean;
+    procedure SetTimedOut(const AValue: Boolean);
 
     property Name : string read GetName;
     property FullName : string read GetFullName;
@@ -73,6 +77,8 @@ type
     property IgnoreReason : string read GetIgnoreReason;
     property TestMethod : TTestMethod read GetTestMethod;
     property IgnoreMemoryLeaks : Boolean read GetIgnoreMemoryLeaks write SetIgnoreMemoryLeaks;
+    property MaxTime: cardinal read GetMaxTime write SetMaxTime;
+    property TimedOut: Boolean read GetTimedOut write SetTimedOut;
   end;
 
   ITestList = interface(IList<ITest>)
@@ -113,7 +119,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = '') : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -245,10 +245,12 @@ var
   testEnabled     : boolean;
   isTestMethod    : boolean;
   repeatAttrib    : RepeatTestAttribute;
+  maxTimeAttrib   : MaxTimeAttribute;
 
   category        : string;
   ignoredTest     : boolean;
   ignoredReason   : string;
+  maxTime         : cardinal;
 
   repeatCount: Cardinal;
   i: Integer;
@@ -294,6 +296,8 @@ begin
     categoryAttrib := nil;
     isTestMethod := false;
     repeatCount := 1;
+    maxTimeAttrib := nil;
+    maxTime := 0;
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;
@@ -302,8 +306,6 @@ begin
     //if the test has a category attribute then we'll use it to override the fixtures's category.
     if method.TryGetAttributeOfType<CategoryAttribute>(categoryAttrib) then
       category := categoryAttrib.Category;
-
-
 
     if method.TryGetAttributeOfType<RepeatTestAttribute>(repeatAttrib) then
     begin
@@ -352,7 +354,6 @@ begin
        continue;
     end;
 
-
     if (not Assigned(setupMethod)) and method.TryGetAttributeOfType<SetupAttribute>(setupAttrib) then
     begin
       setupMethod := TTestMethod(meth);
@@ -369,15 +370,18 @@ begin
 
     if method.TryGetAttributeOfType<IgnoreAttribute>(ignoredAttrib) then
     begin
-       ignoredTest   := true;
-       ignoredReason := ignoredAttrib.Reason;
+      ignoredTest   := true;
+      ignoredReason := ignoredAttrib.Reason;
     end;
 
     if method.TryGetAttributeOfType<TestAttribute>(testAttrib) then
     begin
-       testEnabled := testAttrib.Enabled;
-       isTestMethod := true;
+      testEnabled := testAttrib.Enabled;
+      isTestMethod := true;
     end;
+
+    if method.TryGetAttributeOfType<MaxTimeAttribute>(maxTimeAttrib) then
+      maxTime := maxTimeAttrib.MaxTime;
 
     if method.IsDestructor or method.IsConstructor then
       continue;
@@ -399,7 +403,7 @@ begin
           begin
             for i := 1 to repeatCount do
             begin
-              currentFixture.AddTestCase(method.Name, testCaseAttrib.CaseInfo.Name, FormatTestName(method.Name, i, repeatCount), category, method, testEnabled,testCaseAttrib.CaseInfo.Values);
+              currentFixture.AddTestCase(method.Name, testCaseAttrib.CaseInfo.Name, FormatTestName(method.Name, i, repeatCount), category, method, testEnabled, testCaseAttrib.CaseInfo.Values);
             end;
           end;
           // Add test case from test \case sources
@@ -423,7 +427,7 @@ begin
         else
         begin
           //if a testcase is ignored, just add it as a regular test.
-          currentFixture.AddTest(method.Name, TTestMethod(meth),method.Name,category,true,true,ignoredReason);
+          currentFixture.AddTest(method.Name, TTestMethod(meth), method.Name, category, true, true, ignoredReason, maxTime);
         end;
         continue;
       end;
@@ -433,7 +437,7 @@ begin
     begin
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(method.Name, TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason);
+        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime);
       end;
       continue;
     end;
@@ -444,7 +448,7 @@ begin
       // Add Published Method that has no Attributes
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(method.Name, TTestMethod(meth),FormatTestName(method.Name, i, repeatCount),category,true,ignoredTest,ignoredReason);
+        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime);
       end;
     end;
   end;

--- a/DUnitX.Test.pas
+++ b/DUnitX.Test.pas
@@ -56,6 +56,8 @@ type
     FIgnored      : boolean;
     FIgnoreReason : string;
     FIgnoreMemoryLeaks : Boolean;
+    FMaxTime      : cardinal; // milliseconds for timeout
+    FTimedOut     : Boolean;
   protected
     //ITest
     function GetName: string; virtual;
@@ -69,6 +71,10 @@ type
     function GetTestDuration: TTimeSpan;
     function GetIgnoreMemoryLeaks() : Boolean;
     procedure SetIgnoreMemoryLeaks(const AValue : Boolean);
+    function GetMaxTime: cardinal;
+    procedure SetMaxTime(const AValue: cardinal);
+    function GetTimedOut: Boolean;
+    procedure SetTimedOut(const AValue: Boolean);
 
     //ITestInfo
     function GetActive : boolean;
@@ -86,7 +92,7 @@ type
     procedure Execute(const context : ITestExecuteContext);virtual;
   public
     constructor Create(const AFixture : ITestFixture; const AMethodName : string; const AName : string; const ACategory  : string; const AMethod : TTestMethod; const AEnabled : boolean;
-                       const AIgnored : boolean = false; const AIgnoreReason : string = '');
+                       const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0);
     destructor Destroy;override;
   end;
 
@@ -111,11 +117,12 @@ implementation
 uses
   SysUtils,
   Generics.Defaults,
-  DUnitX.Utils;
+  DUnitX.Utils,
+  DUnitX.Timeout;
 
 { TDUnitXTest }
 
-constructor TDUnitXTest.Create(const AFixture: ITestFixture; const AMethodName : string; const AName: string; const ACategory  : string; const AMethod: TTestMethod; const AEnabled : boolean; const AIgnored : boolean; const AIgnoreReason : string);
+constructor TDUnitXTest.Create(const AFixture: ITestFixture; const AMethodName : string; const AName: string; const ACategory  : string; const AMethod: TTestMethod; const AEnabled : boolean; const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime : Cardinal);
 var
   categories : TArray<string>;
   cat        : string;
@@ -141,6 +148,8 @@ begin
   FEnabled := AEnabled;
   FIgnored := AIgnored;
   FIgnoreReason := AIgnoreReason;
+  FMaxTime := AMaxTime;
+  FTimedOut := false;
 end;
 
 destructor TDUnitXTest.Destroy;
@@ -153,6 +162,9 @@ procedure TDUnitXTest.Execute(const context : ITestExecuteContext);
 begin
   FStartTime := Now();
   try
+    if FMaxTime > 0 then
+      InitialiseTimeOut( FMaxTime );
+
     FMethod();
   finally
     FEndTime := Now();
@@ -252,6 +264,24 @@ end;
 procedure TDUnitXTest.SetIgnoreMemoryLeaks(const AValue: Boolean);
 begin
   FIgnoreMemoryLeaks := AValue;
+end;
+
+function TDUnitXTest.GetMaxTime: cardinal;
+begin
+  Result := FMaxTime;
+end;
+procedure TDUnitXTest.SetMaxTime(const AValue: cardinal);
+begin
+  FMaxTime := AValue;
+end;
+
+function TDUnitXTest.GetTimedOut: Boolean;
+begin
+  Result := FTimedOut;
+end;
+procedure TDUnitXTest.SetTimedOut(const AValue: Boolean);
+begin
+  FTimedOut := AValue;
 end;
 
 procedure TDUnitXTest.SetResult(const value: ITestResult);

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -115,7 +115,7 @@ type
 
     procedure ExecuteFixtureTearDown;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = '') : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -505,9 +505,9 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string): ITest;
+function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal): ITest;
 begin
-  result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod,AEnabled,AIgnored,AIgnoreReason);
+  result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime);
   FTests.Add(Result);
 end;
 

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -66,7 +66,7 @@ type
   CategoryAttribute = DUnitX.Attributes.CategoryAttribute;
   IgnoreAttribute = DUnitX.Attributes.IgnoreAttribute;
   RepeatTestAttribute = DUnitX.Attributes.RepeatTestAttribute;
-
+  MaxTimeAttribute =  DUnitX.Attributes.MaxTimeAttribute;
   TestCaseInfo = DUnitX.Attributes.TestCaseInfo;
   TestCaseInfoArray = DUnitX.Attributes.TestCaseInfoArray;
 
@@ -580,6 +580,8 @@ type
 
   ETestFailure = class(EAbort);
   ETestPass = class(EAbort);
+  ETimedOut = class(EAbort);
+
   ENoTestsRegistered = class(ETestFrameworkException);
   ECommandLineError = class(ETestFrameworkException);
 

--- a/DUnitX.TestRunner.pas
+++ b/DUnitX.TestRunner.pas
@@ -106,6 +106,7 @@ type
     function ExecuteTest(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const memoryAllocationProvider : IMemoryLeakMonitor) : ITestResult;
     function ExecuteSuccessfulResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const message: string = '') : ITestResult;
     function ExecuteFailureResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
+    function ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
     function ExecuteErrorResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
     function ExecuteIgnoredResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const ignoreReason : string) : ITestResult;
 
@@ -699,7 +700,7 @@ begin
       memoryAllocationProvider.PostTest;
     end;
 
-    if FFailsOnNoAsserts then
+    if (FFailsOnNoAsserts) then
     begin
       assertAfterCount := TDUnitX.GetAssertCount(threadId);
       if (assertBeforeCount = assertAfterCount)  then
@@ -767,6 +768,8 @@ begin
           testResult := ExecuteSuccessfulResult(context, threadId, test, e.Message);
         on e: ETestFailure do
           testResult := ExecuteFailureResult(context, threadId, test, e);
+        on e: ETimedOut do
+          testResult := ExecuteTimedOutResult(context, threadId, test, e);
         on e: Exception do
           testResult := ExecuteErrorResult(context, threadId, test, e);
       end;
@@ -839,6 +842,11 @@ begin
 end;
 
 
+
+function TDUnitXTestRunner.ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception: Exception): ITestError;
+begin
+  Result := TDUnitXTestError.Create(test as ITestInfo, TTestResultType.Failure, exception, ExceptAddr, exception.Message);
+end;
 
 function TDUnitXTestRunner.GetUseRTTI: Boolean;
 begin

--- a/DUnitX.Timeout.pas
+++ b/DUnitX.Timeout.pas
@@ -17,7 +17,13 @@ implementation
 
 uses
   DUnitX.TestFramework,
+  DUnitX.Utils,
   Windows;
+
+// The following TimeOut code is based on the code found at
+// https://code.google.com/p/delphitimeouts/
+// DelphiTimeouts version 1.1
+// Copyright (c) 2007-2008 Szymon Jachim
 
 type
   TTimeoutThread = class(TThread)
@@ -99,7 +105,7 @@ begin
   //Get the tickcount so that we leave timing up to the system.
   startTime := GetTickCount;
 
-  while (GetTickCount() >= startTime + Timeout) do
+  while (GetElapsedTime(startTime) >= Timeout) do
   begin
     //Give some time back to the system to process the test.
     Sleep(1);

--- a/DUnitX.Timeout.pas
+++ b/DUnitX.Timeout.pas
@@ -1,0 +1,117 @@
+unit DUnitX.Timeout;
+
+interface
+
+uses
+  Classes;
+
+type
+  ITimeout = interface(IUnknown)
+    ['{0A380F7B-9CEE-4FD7-9D86-60CE05B97C1A}']
+    procedure Stop;
+  end;
+
+  function InitialiseTimeout(const ATime: cardinal): ITimeout;
+
+implementation
+
+uses
+  DUnitX.TestFramework,
+  Windows;
+
+type
+  TTimeoutThread = class(TThread)
+  private
+    procedure TimeoutThread;
+  public
+    ThreadHandle: Cardinal;
+    Timeout: Cardinal;
+    procedure Execute; override;
+  end;
+
+  TTimeout = class(TInterfacedObject, ITimeout)
+  private
+    FTimeoutThread: TTimeoutThread;
+  public
+    constructor Create(const ATimeout: Cardinal; AThreadHandle: THandle);
+    destructor Destroy; override;
+
+    procedure Stop;
+  end;
+
+function InitialiseTimeout(const ATime: cardinal): ITimeout;
+var
+  ThisThreadHandle: THandle;
+begin
+  DuplicateHandle(GetCurrentProcess, GetCurrentThread, GetCurrentProcess, @ThisThreadHandle, 0, True, DUPLICATE_SAME_ACCESS);
+  Result := TTimeout.Create(ATime, ThisThreadHandle);
+end;
+
+procedure RaiseTimeOutException;
+begin
+  raise ETimedOut.Create('Operation Timed Out');
+end;
+
+procedure TTimeoutThread.TimeoutThread;
+var
+  Ctx: _CONTEXT;
+begin
+  SuspendThread(ThreadHandle);
+  Ctx.ContextFlags := CONTEXT_FULL;
+  GetThreadContext(ThreadHandle, Ctx);
+  Ctx.Eip := Cardinal(@RaiseTimeOutException);
+  SetThreadContext(ThreadHandle, Ctx);
+  ResumeThread(ThreadHandle);
+end;
+
+{ TTimeout }
+
+procedure TTimeout.Stop;
+begin
+  FTimeoutThread.Terminate;
+end;
+
+constructor TTimeout.Create(const ATimeout: Cardinal; AThreadHandle: THandle);
+begin
+  FTimeoutThread := TTimeoutThread.Create(true);
+  FTimeoutThread.FreeOnTerminate := true;
+  FTimeoutThread.ThreadHandle := AThreadHandle;
+  FTimeoutThread.Timeout := ATimeout;
+  FTimeoutThread.Resume;
+end;
+
+destructor TTimeout.Destroy;
+begin
+  //Unwinding and we need to stop the thread, as it may still raise an exception
+  Stop;
+  inherited;
+end;
+
+{ TTimeoutThread }
+
+procedure TTimeoutThread.Execute;
+var
+  I: Integer;
+  startTime: Cardinal;
+begin
+  inherited;
+
+  //Get the tickcount so that we leave timing up to the system.
+  startTime := GetTickCount;
+
+  while (GetTickCount() >= startTime + Timeout) do
+  begin
+    //Give some time back to the system to process the test.
+    Sleep(1);
+
+    if Terminated then
+      Break;
+  end;
+
+  //If we haven't been terminated then we have timed out.
+  if not Terminated then
+    TimeoutThread;
+end;
+
+
+end.

--- a/DUnitX.Utils.pas
+++ b/DUnitX.Utils.pas
@@ -727,6 +727,7 @@ function Supports(const Instance: TValue; const IID: TGUID; out Intf): Boolean; 
 const
   ObjCastGUID: TGUID = '{CEDF24DE-80A4-447D-8C75-EB871DC121FD}';
 
+
 implementation
 
 uses
@@ -734,7 +735,8 @@ uses
   Generics.Defaults,
   Math,
   StrUtils,
-  SysConst;
+  SysConst,
+  Windows;
 
 var
   Context: TRttiContext;
@@ -753,6 +755,7 @@ var
   attribute : TCustomAttribute;
 begin
   result := nil;
+
   for attribute in attributes do
   begin
     if attribute.ClassType = AttributeClass then

--- a/DUnitX.Utils.pas
+++ b/DUnitX.Utils.pas
@@ -105,6 +105,8 @@ type
     class function ToArray(const values : TList<string>) : TArray<string>;
   end;
 
+  function GetElapsedTime(const ALastTick : Cardinal) : Cardinal;
+
 type
   {$REGION 'Documentation'}
   ///	<summary>
@@ -3136,6 +3138,18 @@ begin
   for i := 0 to values.Count - 1 do
     result[i] := values[i];
 end;
+
+function GetElapsedTime(const ALastTick : Cardinal) : Cardinal;
+var
+  CurrentTick : Cardinal;
+begin
+  CurrentTick := GetTickCount;
+  if CurrentTick >= ALastTick then
+    Result := CurrentTick - ALastTick
+  else
+    Result := (High(Cardinal) - ALastTick) + CurrentTick;
+end;
+
 
 initialization
   Enumerations := TObjectDictionary<PTypeInfo, TStrings>.Create([doOwnsValues]);

--- a/Tests/DUnitX.Tests.TestFixture.pas
+++ b/Tests/DUnitX.Tests.TestFixture.pas
@@ -99,6 +99,25 @@ type
   end;
   {$M-}
 
+  {$M+}
+  [TestFixture]
+  TTestMaxTimeAttribute = class
+  public
+    [Test]
+    [MaxTime(0)]
+    procedure MaxTimeIsZero;
+
+
+    [Test]
+    [MaxTime(100)]
+    procedure TestTimeout;
+
+    [Test]
+    [MaxTime(100)]
+    procedure TestDoesNotTimeout;
+  end;
+  {$M-}
+
 implementation
 
 uses
@@ -194,9 +213,31 @@ begin
   Assert.AreEqual(TIMES_RUN_TEST_CASE, _TimesRunTestCase, 'TimesRunTestCase');
 end;
 
+{ TTestMaxTimeAttribute }
+
+procedure TTestMaxTimeAttribute.MaxTimeIsZero;
+begin
+  Sleep( 100 );
+  Assert.Pass;  // even after a delay,
+                // the test should not timeout, as zero means no timeout
+end;
+
+procedure TTestMaxTimeAttribute.TestTimeout;
+begin
+  Sleep( 150 );
+  Assert.Fail('Timeout should catch this test.');  // the test should time out before this point
+end;
+
+procedure TTestMaxTimeAttribute.TestDoesNotTimeout;
+begin
+  Assert.Pass;  // the test should NOT time out before this point
+end;
+
+
 initialization
   TDUnitX.RegisterTestFixture(TTestClassWithNonPublicSetup);
   TDUnitX.RegisterTestFixture(TTestClassWithTestSource);
   TDUnitX.RegisterTestFixture(TTestRepeatAttribute);
+  TDUnitX.RegisterTestFixture(TTestMaxTimeAttribute);
 
 end.

--- a/Tests/DUnitX.Tests.TestFixture.pas
+++ b/Tests/DUnitX.Tests.TestFixture.pas
@@ -107,8 +107,8 @@ type
     [MaxTime(0)]
     procedure MaxTimeIsZero;
 
-
-    [Test]
+    //We ignore the timeout test for the moment. We require a way to test timeout without calling it to fail the test itself.
+    [Test, Ignore]
     [MaxTime(100)]
     procedure TestTimeout;
 

--- a/Tests/DUnitXTest_XE7.dpr
+++ b/Tests/DUnitXTest_XE7.dpr
@@ -62,7 +62,8 @@ uses
   DUnitX.Tests.Inheritance in 'DUnitX.Tests.Inheritance.pas',
   DUnitX.Tests.ConsoleWriter.Base in 'DUnitX.Tests.ConsoleWriter.Base.pas',
   DUnitX.Assert in '..\DUnitX.Assert.pas',
-  DUnitX.Types in '..\DUnitX.Types.pas';
+  DUnitX.Types in '..\DUnitX.Types.pas',
+  DUnitX.Timeout in '..\DUnitX.Timeout.pas';
 
 var
   runner : ITestRunner;

--- a/Tests/DUnitXTest_XE7.dproj
+++ b/Tests/DUnitXTest_XE7.dproj
@@ -131,6 +131,7 @@
         <DCCReference Include="DUnitX.Tests.ConsoleWriter.Base.pas"/>
         <DCCReference Include="..\DUnitX.Assert.pas"/>
         <DCCReference Include="..\DUnitX.Types.pas"/>
+        <DCCReference Include="..\DUnitX.Timeout.pas"/>
         <None Include="..\DUnitX.inc"/>
         <None Include="..\DUnitX.Stacktrace.inc"/>
         <None Include="..\DUnitX.MemoryLeaks.inc"/>


### PR DESCRIPTION
First implemented by MartinSedgewick/DUnitX - MaxTimeAttribute

The new attribute allows the user to set the maximum amount of time a test should run. Zero is the default for any test, which means that the timeout will not be tested. The timeout also runs in a seperate thread to make sure it does not interfere with the processing of the test. 