### PR TITLE
Fixed thread timeout exception being called on released thread.

### DIFF
--- a/DUnitX.Timeout.pas
+++ b/DUnitX.Timeout.pas
@@ -80,7 +80,7 @@ end;
 constructor TTimeout.Create(const ATimeout: Cardinal; AThreadHandle: THandle);
 begin
   FTimeoutThread := TTimeoutThread.Create(true);
-  FTimeoutThread.FreeOnTerminate := true;
+  FTimeoutThread.FreeOnTerminate := false;
   FTimeoutThread.ThreadHandle := AThreadHandle;
   FTimeoutThread.Timeout := ATimeout;
   FTimeoutThread.Resume;
@@ -90,6 +90,8 @@ destructor TTimeout.Destroy;
 begin
   //Unwinding and we need to stop the thread, as it may still raise an exception
   Stop;
+  FTimeoutThread.WaitFor;
+  FTimeoutThread.Free;
   inherited;
 end;
 


### PR DESCRIPTION
Previously the timeout exception could be called and the thread was released. Now we wait for and then release the thread ourselves to make sure of its lifecycle.