### PR TITLE
Feature/threadid

### DIFF
--- a/DUNitX.Loggers.GUIX.pas
+++ b/DUNitX.Loggers.GUIX.pas
@@ -85,27 +85,27 @@ type
     function GetNode(FullName: String): TTreeViewItem;
     procedure BuildTree(parentNode: TTreeViewItem; const fixtureList: ITestFixtureList);
   protected
-    procedure OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTest(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
-    procedure OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
     procedure OnLog(const logType: TLogLevel; const msg: string);
-    procedure OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnTestError(const threadId: Cardinal; const Error: ITestError);
-    procedure OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
-    procedure OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const AIgnored: ITestResult);
-    procedure OnTestIgnored(const threadId: Cardinal; const Ignored: ITestResult);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const AIgnored: ITestResult);
+    procedure OnTestIgnored(const threadId: TThreadID; const Ignored: ITestResult);
     procedure OnTestingEnds(const RunResults: IRunResults);
-    procedure OnTestingStarts(const threadId: Cardinal; const testCount: Cardinal; const testActiveCount: Cardinal);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
   public
     { Public declarations }
   end;
@@ -232,37 +232,37 @@ begin
   until Assigned(Result) or (i >= TestTree.GlobalCount);
 end;
 
-procedure TGUIXTestRunner.OnBeginTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnBeginTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnEndSetupFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndSetupFixture(const threadId: TThreadID;
   const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnEndSetupTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndSetupTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnEndTearDownFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndTearDownFixture(const threadId: TThreadID;
   const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnEndTeardownTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndTeardownTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnEndTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndTest(const threadId: TThreadID;
   const Test: ITestResult);
 var
   failItem: TListViewItem;
@@ -284,7 +284,7 @@ begin
   end;
 end;
 
-procedure TGUIXTestRunner.OnEndTestFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnEndTestFixture(const threadId: TThreadID;
   const results: IFixtureResult);
 var
   fixtureNode: TTestNode;
@@ -309,7 +309,7 @@ begin
 
 end;
 
-procedure TGUIXTestRunner.OnExecuteTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnExecuteTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
@@ -320,49 +320,49 @@ begin
 
 end;
 
-procedure TGUIXTestRunner.OnSetupFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnSetupFixture(const threadId: TThreadID;
   const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnSetupTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnSetupTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnStartTestFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnStartTestFixture(const threadId: TThreadID;
   const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTearDownFixture(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTearDownFixture(const threadId: TThreadID;
   const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTeardownTest(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTeardownTest(const threadId: TThreadID;
   const Test: ITestInfo);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestError(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTestError(const threadId: TThreadID;
   const Error: ITestError);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestFailure(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTestFailure(const threadId: TThreadID;
   const Failure: ITestError);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestIgnored(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTestIgnored(const threadId: TThreadID;
   const Ignored: ITestResult);
 begin
 
@@ -373,19 +373,19 @@ begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestingStarts(const threadId, testCount,
+procedure TGUIXTestRunner.OnTestingStarts(const threadId: TThreadID; testCount,
   testActiveCount: Cardinal);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestMemoryLeak(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTestMemoryLeak(const threadId: TThreadID;
   const AIgnored: ITestResult);
 begin
 
 end;
 
-procedure TGUIXTestRunner.OnTestSuccess(const threadId: Cardinal;
+procedure TGUIXTestRunner.OnTestSuccess(const threadId: TThreadID;
   const Test: ITestResult);
 begin
 

--- a/DUnitX.Loggers.Console.pas
+++ b/DUnitX.Loggers.Console.pas
@@ -51,36 +51,36 @@ type
     procedure SetConsoleSummaryColor(); virtual;
     procedure SetConsoleWarningColor(); virtual;
   protected
-    procedure OnTestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 
-    procedure OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnExecuteTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
-    procedure OnTestIgnored(const threadId: Cardinal;const  AIgnored: ITestResult);
-    procedure OnTestError(const threadId: Cardinal; const Error: ITestError);
-    procedure OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
-    procedure OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
+    procedure OnTestMemoryLeak(const threadId : TThreadID; const Test: ITestResult);
+    procedure OnTestIgnored(const threadId: TThreadID; const  AIgnored: ITestResult);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
     procedure OnLog(const logType : TLogLevel; const msg : string);
 
-    procedure OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnEndTest(const threadId: Cardinal; const Test: ITestResult);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 
-    procedure OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 
     procedure OnTestingEnds(const RunResults: IRunResults);
   public
@@ -113,7 +113,7 @@ begin
   inherited;
 end;
 
-procedure TDUnitXConsoleLogger.OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXConsoleLogger.OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
   if FQuietMode then
     exit;
@@ -122,7 +122,7 @@ begin
   FConsoleWriter.WriteLn;
 end;
 
-procedure TDUnitXConsoleLogger.OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
   if FQuietMode then
     exit;
@@ -132,17 +132,17 @@ begin
   FConsoleWriter.WriteLn;
 end;
 
-procedure TDUnitXConsoleLogger.OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXConsoleLogger.OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXConsoleLogger.OnEndTeardownTest(const threadId: Cardinal; const  Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnEndTeardownTest(const threadId: TThreadID; const  Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXConsoleLogger.OnEndTest(const threadId: Cardinal; const  Test: ITestResult);
+procedure TDUnitXConsoleLogger.OnEndTest(const threadId: TThreadID; const  Test: ITestResult);
 begin
   if FQuietMode then
     exit;
@@ -151,7 +151,7 @@ begin
   FConsoleWriter.WriteLn;
 end;
 
-procedure TDUnitXConsoleLogger.OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+procedure TDUnitXConsoleLogger.OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 begin
   if FQuietMode then
     exit;
@@ -160,7 +160,7 @@ begin
   FConsoleWriter.WriteLn;
 end;
 
-procedure TDUnitXConsoleLogger.OnExecuteTest(const threadId: Cardinal; const  Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnExecuteTest(const threadId: TThreadID; const  Test: ITestInfo);
 begin
   if FQuietMode then
   begin
@@ -176,7 +176,7 @@ begin
   //SetConsoleDefaultColor();
 end;
 
-procedure TDUnitXConsoleLogger.OnTestError(const threadId: Cardinal; const  Error: ITestError);
+procedure TDUnitXConsoleLogger.OnTestError(const threadId: TThreadID; const  Error: ITestError);
 begin
   if FQuietMode then
   begin
@@ -185,7 +185,7 @@ begin
   end;
 end;
 
-procedure TDUnitXConsoleLogger.OnTestFailure(const threadId: Cardinal; const  Failure: ITestError);
+procedure TDUnitXConsoleLogger.OnTestFailure(const threadId: TThreadID; const  Failure: ITestError);
 begin
   if FQuietMode then
   begin
@@ -194,7 +194,7 @@ begin
   end;
 end;
 
-procedure TDUnitXConsoleLogger.OnTestIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
+procedure TDUnitXConsoleLogger.OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
 begin
   if FQuietMode then
     FConsoleWriter.Write('I');
@@ -222,7 +222,7 @@ begin
   end;
 end;
 
-procedure TDUnitXConsoleLogger.OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXConsoleLogger.OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
   if FQuietMode then
     exit;
@@ -232,7 +232,7 @@ begin
 
 end;
 
-procedure TDUnitXConsoleLogger.OnSetupTest(const threadId: Cardinal; const  Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnSetupTest(const threadId: TThreadID; const  Test: ITestInfo);
 begin
   if FQuietMode then
     exit;
@@ -241,7 +241,7 @@ begin
   FConsoleWriter.WriteLn('Running Setup for : ' + Test.Name);
 end;
 
-procedure TDUnitXConsoleLogger.OnBeginTest(const threadId: Cardinal; const  Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnBeginTest(const threadId: TThreadID; const  Test: ITestInfo);
 begin
   if FQuietMode then
     exit;
@@ -253,7 +253,7 @@ begin
   SetConsoleDefaultColor();
 end;
 
-procedure TDUnitXConsoleLogger.OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXConsoleLogger.OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
   if FQuietMode then
     exit;
@@ -267,7 +267,7 @@ begin
 end;
 
 
-procedure TDUnitXConsoleLogger.OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXConsoleLogger.OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
 begin
   if FQuietMode then
   begin
@@ -281,7 +281,7 @@ begin
   FConsoleWriter.Outdent(2);
 end;
 
-procedure TDUnitXConsoleLogger.OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXConsoleLogger.OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
   if FQuietMode then
     exit;
@@ -290,7 +290,7 @@ begin
   FConsoleWriter.WriteLn;
 end;
 
-procedure TDUnitXConsoleLogger.OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXConsoleLogger.OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
   if FQuietMode then
     exit;
@@ -422,7 +422,7 @@ begin
   SetConsoleDefaultColor();
 end;
 
-procedure TDUnitXConsoleLogger.OnTestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+procedure TDUnitXConsoleLogger.OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount : Cardinal);
 begin
   if FQuietMode then
   begin
@@ -433,7 +433,7 @@ begin
 end;
 
 
-procedure TDUnitXConsoleLogger.OnTestMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXConsoleLogger.OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 begin
   if FQuietMode then
     FConsoleWriter.Write('M');

--- a/DUnitX.Loggers.GUI.pas
+++ b/DUnitX.Loggers.GUI.pas
@@ -68,27 +68,27 @@ type
     procedure BuildTree(parentNode: TTreeNode; const fixtureList: ITestFixtureList);
   protected
 
-    procedure OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTest(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
-    procedure OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
     procedure OnLog(const logType: TLogLevel; const msg: string);
-    procedure OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnTestError(const threadId: Cardinal; const Error: ITestError);
-    procedure OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
-    procedure OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
-    procedure OnTestIgnored(const threadId: Cardinal; const Ignored: ITestResult);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestIgnored(const threadId: TThreadID; const Ignored: ITestResult);
     procedure OnTestingEnds(const RunResults: IRunResults);
-    procedure OnTestingStarts(const threadId: Cardinal; const testCount: Cardinal; const testActiveCount: Cardinal);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 
     procedure WMLoadTests(var message : TMessage); message WM_LOAD_TESTS;
     procedure Loaded; override;
@@ -120,42 +120,42 @@ begin
   PostMessage(Self.Handle,WM_LOAD_TESTS,0,0);
 end;
 
-procedure TDUnitXGuiLoggerForm.OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXGuiLoggerForm.OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXGuiLoggerForm.OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndTest(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXGuiLoggerForm.OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+procedure TDUnitXGuiLoggerForm.OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
@@ -165,42 +165,42 @@ begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXGuiLoggerForm.OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXGuiLoggerForm.OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXGuiLoggerForm.OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXGuiLoggerForm.OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestError(const threadId: Cardinal; const Error: ITestError);
+procedure TDUnitXGuiLoggerForm.OnTestError(const threadId: TThreadID; const Error: ITestError);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
+procedure TDUnitXGuiLoggerForm.OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestIgnored(const threadId: Cardinal; const Ignored: ITestResult);
+procedure TDUnitXGuiLoggerForm.OnTestIgnored(const threadId: TThreadID; const Ignored: ITestResult);
 begin
 
 end;
@@ -210,17 +210,17 @@ begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestingStarts(const threadId, testCount, testActiveCount: Cardinal);
+procedure TDUnitXGuiLoggerForm.OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXGuiLoggerForm.OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXGuiLoggerForm.OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXGuiLoggerForm.OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;

--- a/DUnitX.Loggers.Null.pas
+++ b/DUnitX.Loggers.Null.pas
@@ -35,27 +35,27 @@ type
   ///  A Base class for loggers that do not need to use every interface method.
   TDUnitXNullLogger = class(TInterfacedObject,ITestLogger)
   protected
-    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
-    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
-    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
-    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnLog(const logType: TLogLevel; const msg: string);
-    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
-    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
-    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
-    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
-    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
-    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
-    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
-    procedure OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
-    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
-    procedure OnTestingEnds(const RunResults: IRunResults);
-    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo); virtual;
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo); virtual;
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult); virtual;
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult); virtual;
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnLog(const logType: TLogLevel; const msg: string); virtual;
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo); virtual;
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo); virtual;
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo); virtual;
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo); virtual;
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError); virtual;
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError); virtual;
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult); virtual;
+    procedure OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult); virtual;
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult); virtual;
+    procedure OnTestingEnds(const RunResults: IRunResults); virtual;
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal); virtual;
   end;
 
 implementation

--- a/DUnitX.Loggers.Null.pas
+++ b/DUnitX.Loggers.Null.pas
@@ -35,69 +35,69 @@ type
   ///  A Base class for loggers that do not need to use every interface method.
   TDUnitXNullLogger = class(TInterfacedObject,ITestLogger)
   protected
-    procedure OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTest(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
-    procedure OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
     procedure OnLog(const logType: TLogLevel; const msg: string);
-    procedure OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnTestError(const threadId: Cardinal; const Error: ITestError);
-    procedure OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
-    procedure OnTestIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
-    procedure OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnTestingEnds(const RunResults: IRunResults);virtual;
-    procedure OnTestingStarts(const threadId: Cardinal; const testCount: Cardinal; const testActiveCount: Cardinal);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestingEnds(const RunResults: IRunResults);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
   end;
 
 implementation
 
 { TDUnitXNullLogger }
 
-procedure TDUnitXNullLogger.OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXNullLogger.OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXNullLogger.OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndTest(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXNullLogger.OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+procedure TDUnitXNullLogger.OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
@@ -107,42 +107,42 @@ begin
 
 end;
 
-procedure TDUnitXNullLogger.OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXNullLogger.OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXNullLogger.OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXNullLogger.OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXNullLogger.OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestError(const threadId: Cardinal; const Error: ITestError);
+procedure TDUnitXNullLogger.OnTestError(const threadId: TThreadID; const Error: ITestError);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
+procedure TDUnitXNullLogger.OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
+procedure TDUnitXNullLogger.OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
 begin
 
 end;
@@ -152,17 +152,17 @@ begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestingStarts(const threadId, testCount, testActiveCount: Cardinal);
+procedure TDUnitXNullLogger.OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXNullLogger.OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXNullLogger.OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXNullLogger.OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;

--- a/DUnitX.Loggers.Text.pas
+++ b/DUnitX.Loggers.Text.pas
@@ -40,39 +40,39 @@ type
   private
     //FFileName : string;
   protected
-    procedure OnTestingStarts(const threadId, testCount, testActiveCount: Cardinal);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 
-    procedure OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnExecuteTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 
 
-    procedure OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
-    procedure OnTestError(const threadId: Cardinal; const Error: ITestError);
-    procedure OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
-    procedure OnTestIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 
     procedure OnLog(const logType: TLogLevel; const msg : string);
 
-    procedure OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
-    procedure OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure OnEndTest(const threadId: Cardinal; const Test: ITestResult);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 
 
-    procedure OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
-    procedure OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 
     procedure OnTestingEnds(const RunResults: IRunResults);
   public
@@ -89,52 +89,52 @@ begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTextFileLogger.OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTextFileLogger.OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndTest(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXTextFileLogger.OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnEndTestFixture(const threadId: Cardinal; const results: IFixtureResult);
+procedure TDUnitXTextFileLogger.OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTestError(const threadId: Cardinal; const Error: ITestError);
+procedure TDUnitXTextFileLogger.OnTestError(const threadId: TThreadID; const Error: ITestError);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTestFailure(const threadId: Cardinal; const Failure: ITestError);
+procedure TDUnitXTextFileLogger.OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTestIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
+procedure TDUnitXTextFileLogger.OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
 begin
 
 end;
@@ -144,38 +144,38 @@ begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTextFileLogger.OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnBeginTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnStartTestFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTextFileLogger.OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
 
-procedure TDUnitXTextFileLogger.OnTestSuccess(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXTextFileLogger.OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTearDownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTextFileLogger.OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTextFileLogger.OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 begin
 
 end;
@@ -185,13 +185,13 @@ begin
 
 end;
 
-procedure TDUnitXTextFileLogger.OnTestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+procedure TDUnitXTextFileLogger.OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount : Cardinal);
 begin
 
 end;
 
 
-procedure TDUnitXTextFileLogger.OnTestMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXTextFileLogger.OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 begin
 
 end;

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -325,102 +325,102 @@ type
     ///	  Called at the start of testing. The default console logger prints the
     ///	  DUnitX banner.
     ///	</summary>
-    procedure OnTestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+    procedure OnTestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 
     ///	<summary>
     ///	  //Called before a Fixture is run.
     ///	</summary>
-    procedure OnStartTestFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure OnStartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
     ///	<summary>
     ///	  //Called before a fixture Setup method is run
     ///	</summary>
-    procedure OnSetupFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure OnSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
     ///	<summary>
     ///	  Called after a fixture setup method is run.
     ///	</summary>
-    procedure OnEndSetupFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure OnEndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
     ///	<summary>
     ///	  Called before a Test method is run.
     ///	</summary>
-    procedure OnBeginTest(const threadId : Cardinal;const  Test: ITestInfo);
+    procedure OnBeginTest(const threadId: TThreadID; const Test: ITestInfo);
 
     ///	<summary>
     ///	  Called before a test setup method is run.
     ///	</summary>
-    procedure OnSetupTest(const threadId : Cardinal;const  Test: ITestInfo);
+    procedure OnSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 
     ///	<summary>
     ///	  Called after a test setup method is run.
     ///	</summary>
-    procedure OnEndSetupTest(const threadId : Cardinal;const  Test: ITestInfo);
+    procedure OnEndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 
     ///	<summary>
     ///	  Called before a Test method is run.
     ///	</summary>
-    procedure OnExecuteTest(const threadId : Cardinal;const  Test: ITestInfo);
+    procedure OnExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 
     ///	<summary>
     ///	  Called when a test succeeds
     ///	</summary>
-    procedure OnTestSuccess(const threadId : Cardinal;const  Test: ITestResult);
+    procedure OnTestSuccess(const threadId: TThreadID; const Test: ITestResult);
 
     ///	<summary>
     ///	  Called when a test errors.
     ///	</summary>
-    procedure OnTestError(const threadId : Cardinal;const Error: ITestError);
+    procedure OnTestError(const threadId: TThreadID; const Error: ITestError);
 
     ///	<summary>
     ///	  Called when a test fails.
     ///	</summary>
-    procedure OnTestFailure(const threadId : Cardinal;const  Failure: ITestError);
+    procedure OnTestFailure(const threadId: TThreadID; const Failure: ITestError);
 
     /// <summary>
     ///   called when a test is ignored.
     /// </summary>
-    procedure OnTestIgnored(const threadId : Cardinal; const AIgnored: ITestResult);
+    procedure OnTestIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
 
     /// <summary>
     ///   called when a test memory leaks.
     /// </summary>
-    procedure OnTestMemoryLeak(const threadId : Cardinal; const Test: ITestResult);
+    procedure OnTestMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 
     /// <summary>
     ///   allows tests to write to the log.
     /// </summary>
-    procedure OnLog(const logType : TLogLevel; const msg : string);
+    procedure OnLog(const logType: TLogLevel; const msg: string);
 
     /// <summary>
     ///   called before a Test Teardown method is run.
     /// </summary>
-    procedure OnTeardownTest(const threadId : Cardinal;const  Test: ITestInfo);
+    procedure OnTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 
     /// <summary>
     ///   called after a test teardown method is run.
     /// </summary>
-    procedure OnEndTeardownTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure OnEndTeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 
     /// <summary>
     ///   called after a test method and teardown is run.
     /// </summary>
-    procedure OnEndTest(const threadId : Cardinal;const  Test: ITestResult);
+    procedure OnEndTest(const threadId: TThreadID; const Test: ITestResult);
 
     /// <summary>
     ///   called before a Fixture Teardown method is called.
     /// </summary>
-    procedure OnTearDownFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure OnTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
     /// <summary>
     ///   called after a Fixture Teardown method is called.
     /// </summary>
-    procedure OnEndTearDownFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure OnEndTearDownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
     /// <summary>
     ///   called after a Fixture has run.
     /// </summary>
-    procedure OnEndTestFixture(const threadId : Cardinal; const results : IFixtureResult);
+    procedure OnEndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 
     /// <summary>
     ///   called after all fixtures have run.
@@ -519,7 +519,7 @@ type
     class var
       FOptions : TDUnitXOptions;
       FFilter : ITestFilter;
-      FAssertCounters : TDictionary<Cardinal,Cardinal>;
+      FAssertCounters : TDictionary<TThreadID,Cardinal>;
   protected
     class constructor Create;
     class destructor Destroy;
@@ -533,7 +533,7 @@ type
     class procedure RegisterTestFixture(const AClass : TClass; const AName : string = '' );
     class procedure RegisterPlugin(const plugin : IPlugin);
     class function CurrentRunner : ITestRunner;
-    class function GetAssertCount(const AThreadId : Cardinal) : Cardinal;
+    class function GetAssertCount(const AThreadId: TThreadID) : Cardinal;
     ///  Parses the command line options and applies them the the Options object.
     ///  Will throw exception if there are errors.
     class procedure CheckCommandLine;
@@ -728,7 +728,7 @@ end;
 class constructor TDUnitX.Create;
 begin
   FOptions := TDUnitXOptions.Create;
-  FAssertCounters := TDictionary<Cardinal,Cardinal>.Create;
+  FAssertCounters := TDictionary<TThreadID,Cardinal>.Create;
   RegisteredFixtures := TDictionary<TClass,string>.Create;
   RegisteredPlugins  := TList<IPlugin>.Create;
   //Make sure we have at least a dummy memory leak monitor registered.
@@ -737,8 +737,8 @@ begin
   FFilter := nil;
   Assert.OnAssert := procedure
                     var
-                      threadId : Cardinal;
-                      value : cardinal;
+                      threadId: TThreadID;
+                      value: cardinal;
                     begin
                       threadId := TThread.CurrentThread.ThreadID;
                       MonitorEnter(FAssertCounters);
@@ -774,7 +774,7 @@ begin
   FAssertCounters.Free;
 end;
 
-class function TDUnitX.GetAssertCount(const AThreadId: Cardinal): Cardinal;
+class function TDUnitX.GetAssertCount(const AThreadId: TThreadID): Cardinal;
 begin
   result := 0;
   FAssertCounters.TryGetValue(AThreadId,result);

--- a/DUnitX.TestRunner.pas
+++ b/DUnitX.TestRunner.pas
@@ -50,7 +50,7 @@ type
   private class var
     FRttiContext : TRttiContext;
   public class var
-    FActiveRunners : TDictionary<Cardinal,IWeakReference<ITestRunner>>;
+    FActiveRunners : TDictionary<TThreadID,IWeakReference<ITestRunner>>;
   private
     FLoggers          : TList<ITestLogger>;
     FUseRTTI          : boolean;
@@ -64,32 +64,32 @@ type
   protected
     procedure CountAndFilterTests(const fixtureList: ITestFixtureList; var count, active: Cardinal);
     //Logger calls - sequence ordered
-    procedure Loggers_TestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+    procedure Loggers_TestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 
-    procedure Loggers_StartTestFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure Loggers_StartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure Loggers_SetupFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
-    procedure Loggers_EndSetupFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure Loggers_SetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
+    procedure Loggers_EndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure Loggers_BeginTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure Loggers_BeginTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure Loggers_SetupTest(const threadId : Cardinal; const Test: ITestInfo);
-    procedure Loggers_EndSetupTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure Loggers_SetupTest(const threadId: TThreadID; const Test: ITestInfo);
+    procedure Loggers_EndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure Loggers_ExecuteTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure Loggers_ExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure Loggers_AddSuccess(const threadId : Cardinal; const Test: ITestResult);
-    procedure Loggers_AddError(const threadId : Cardinal; const Error: ITestError);
-    procedure Loggers_AddFailure(const threadId : Cardinal; const Failure: ITestError);
-    procedure Loggers_AddIgnored(const threadId : Cardinal; const AIgnored: ITestResult);
-    procedure Loggers_AddMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+    procedure Loggers_AddSuccess(const threadId: TThreadID; const Test: ITestResult);
+    procedure Loggers_AddError(const threadId: TThreadID; const Error: ITestError);
+    procedure Loggers_AddFailure(const threadId: TThreadID; const Failure: ITestError);
+    procedure Loggers_AddIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
+    procedure Loggers_AddMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 
-    procedure Loggers_EndTest(const threadId : Cardinal; const Test: ITestResult);
-    procedure Loggers_TeardownTest(const threadId : Cardinal; const Test: ITestInfo);
+    procedure Loggers_EndTest(const threadId: TThreadID; const Test: ITestResult);
+    procedure Loggers_TeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 
-    procedure Loggers_TeardownFixture(const threadId : Cardinal; const fixture : ITestFixtureInfo);
+    procedure Loggers_TeardownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 
-    procedure Loggers_EndTestFixture(const threadId : Cardinal; const results : IFixtureResult);
+    procedure Loggers_EndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 
     procedure Loggers_TestingEnds(const RunResults: IRunResults);
 
@@ -97,25 +97,25 @@ type
     procedure AddLogger(const value: ITestLogger);
     function Execute: IRunResults;
 
-    procedure ExecuteFixtures(const parentFixtureResult : IFixtureResult; const context: ITestExecuteContext; const threadId: Cardinal; const fixtures: ITestFixtureList);
-    procedure ExecuteSetupFixtureMethod(const threadid: cardinal; const fixture: ITestFixture);
-    function  ExecuteTestSetupMethod(const context : ITestExecuteContext; const threadid: cardinal; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor): boolean;
+    procedure ExecuteFixtures(const parentFixtureResult: IFixtureResult; const context: ITestExecuteContext; const threadId: TThreadID; const fixtures: ITestFixtureList);
+    procedure ExecuteSetupFixtureMethod(const threadId: TThreadID; const fixture: ITestFixture);
+    function  ExecuteTestSetupMethod(const context: ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider: IMemoryLeakMonitor): boolean;
 
-    procedure ExecuteTests(const context : ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture; const fixtureResult : IFixtureResult);
+    procedure ExecuteTests(const context: ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const fixtureResult: IFixtureResult);
 
-    function ExecuteTest(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const memoryAllocationProvider : IMemoryLeakMonitor) : ITestResult;
-    function ExecuteSuccessfulResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const message: string = '') : ITestResult;
-    function ExecuteFailureResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
-    function ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
-    function ExecuteErrorResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception : Exception) : ITestError;
-    function ExecuteIgnoredResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const ignoreReason : string) : ITestResult;
+    function ExecuteTest(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const memoryAllocationProvider: IMemoryLeakMonitor): ITestResult;
+    function ExecuteSuccessfulResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const message: string = ''): ITestResult;
+    function ExecuteFailureResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const exception: Exception): ITestError;
+    function ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const exception: Exception) : ITestError;
+    function ExecuteErrorResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const exception: Exception): ITestError;
+    function ExecuteIgnoredResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const ignoreReason: string): ITestResult;
 
-    function CheckMemoryAllocations(const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor) : boolean;
+    function CheckMemoryAllocations(const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider: IMemoryLeakMonitor): Boolean;
 
-    function ExecuteTestTearDown(const context: ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor) : boolean;
-    procedure ExecuteTearDownFixtureMethod(const context: ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture);
+    function ExecuteTestTearDown(const context: ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider: IMemoryLeakMonitor): Boolean;
+    procedure ExecuteTearDownFixtureMethod(const context: ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture);
 
-    procedure RecordResult(const context: ITestExecuteContext; const threadId: cardinal; const fixtureResult : IFixtureResult; const testResult: ITestResult);
+    procedure RecordResult(const context: ITestExecuteContext; const threadId: TThreadID; const fixtureResult: IFixtureResult; const testResult: ITestResult);
 
     function GetUseRTTI: Boolean;
     procedure SetUseRTTI(const value: Boolean);
@@ -173,7 +173,7 @@ begin
   Self.Log(TLogLevel.Information,msg);
 end;
 
-procedure TDUnitXTestRunner.Loggers_AddError(const threadId : Cardinal; const Error: ITestError);
+procedure TDUnitXTestRunner.Loggers_AddError(const threadId: TThreadID; const Error: ITestError);
 var
   logger : ITestLogger;
 begin
@@ -183,7 +183,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.Loggers_AddFailure(const threadId : Cardinal; const Failure: ITestError);
+procedure TDUnitXTestRunner.Loggers_AddFailure(const threadId: TThreadID; const Failure: ITestError);
 var
   logger : ITestLogger;
 begin
@@ -193,7 +193,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.Loggers_AddIgnored(const threadId: Cardinal; const AIgnored: ITestResult);
+procedure TDUnitXTestRunner.Loggers_AddIgnored(const threadId: TThreadID; const AIgnored: ITestResult);
 var
   logger : ITestLogger;
 begin
@@ -203,7 +203,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.Loggers_AddMemoryLeak(const threadId: Cardinal; const Test: ITestResult);
+procedure TDUnitXTestRunner.Loggers_AddMemoryLeak(const threadId: TThreadID; const Test: ITestResult);
 var
   logger : ITestLogger;
 begin
@@ -219,7 +219,7 @@ begin
     FLoggers.Add(value);
 end;
 
-procedure TDUnitXTestRunner.Loggers_AddSuccess(const threadId : Cardinal; const Test: ITestResult);
+procedure TDUnitXTestRunner.Loggers_AddSuccess(const threadId: TThreadID; const Test: ITestResult);
 var
   logger : ITestLogger;
 begin
@@ -259,7 +259,7 @@ end;
 class constructor TDUnitXTestRunner.Create;
 begin
   FRttiContext := TRttiContext.Create;
-  FActiveRunners := TDictionary<Cardinal,IWeakReference<ITestRunner>>.Create;
+  FActiveRunners := TDictionary<TThreadID,IWeakReference<ITestRunner>>.Create;
 end;
 
 function TDUnitXTestRunner.CheckMemoryAllocations(const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider: IMemoryLeakMonitor): boolean;
@@ -350,7 +350,7 @@ end;
 
 destructor TDUnitXTestRunner.Destroy;
 var
-  tId : Cardinal;
+  tId: TThreadID;
 begin
   MonitorEnter(TDUnitXTestRunner.FActiveRunners);
   try
@@ -372,7 +372,7 @@ begin
   FRttiContext.Free;
 end;
 
-procedure TDUnitXTestRunner.RecordResult(const context: ITestExecuteContext; const threadId: cardinal; const fixtureResult : IFixtureResult; const testResult: ITestResult);
+procedure TDUnitXTestRunner.RecordResult(const context: ITestExecuteContext; const threadId: TThreadID; const fixtureResult : IFixtureResult; const testResult: ITestResult);
 begin
   case testResult.ResultType of
     TTestResultType.Pass:
@@ -439,7 +439,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.Loggers_EndSetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTestRunner.Loggers_EndSetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 var
   logger : ITestLogger;
 begin
@@ -447,7 +447,7 @@ begin
      logger.OnEndSetupFixture(threadId,fixture);
 end;
 
-procedure TDUnitXTestRunner.Loggers_EndSetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTestRunner.Loggers_EndSetupTest(const threadId: TThreadID; const Test: ITestInfo);
 var
   logger : ITestLogger;
 begin
@@ -471,7 +471,7 @@ begin
 
 end;
 
-procedure TDUnitXTestRunner.Loggers_EndTest(const threadId : Cardinal; const Test: ITestResult);
+procedure TDUnitXTestRunner.Loggers_EndTest(const threadId: TThreadID; const Test: ITestResult);
 var
   logger : ITestLogger;
 begin
@@ -480,7 +480,7 @@ begin
 
 end;
 
-procedure TDUnitXTestRunner.Loggers_EndTestFixture(const threadId : Cardinal; const results: IFixtureResult);
+procedure TDUnitXTestRunner.Loggers_EndTestFixture(const threadId: TThreadID; const results: IFixtureResult);
 var
   logger : ITestLogger;
 begin
@@ -490,7 +490,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.Loggers_ExecuteTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTestRunner.Loggers_ExecuteTest(const threadId: TThreadID; const Test: ITestInfo);
 var
   logger : ITestLogger;
 begin
@@ -531,7 +531,7 @@ function TDUnitXTestRunner.Execute: IRunResults;
 var
   fixtureList : ITestFixtureList;
   context : ITestExecuteContext;
-  threadId : Cardinal;
+  threadId : TThreadID;
   testCount : Cardinal;
   testActiveCount : Cardinal;
   fixtures : IInterface;
@@ -568,7 +568,7 @@ begin
 end;
 
 function TDUnitXTestRunner.ExecuteErrorResult(
-  const context: ITestExecuteContext; const threadId: cardinal;
+  const context: ITestExecuteContext; const threadId: TThreadID;
   const test: ITest; const exception: Exception) : ITestError;
 begin
   Result := TDUnitXTestError.Create(test as ITestInfo, TTestResultType.Error, exception, ExceptAddr, exception.Message);
@@ -589,14 +589,14 @@ begin
 end;
 
 function TDUnitXTestRunner.ExecuteFailureResult(
-  const context: ITestExecuteContext; const threadId: cardinal;
+  const context: ITestExecuteContext; const threadId: TThreadID;
   const test: ITest; const exception : Exception) : ITestError;
 begin
   //TODO: Does test failure require its own results interface and class?
   Result := TDUnitXTestError.Create(test as ITestInfo, TTestResultType.Failure, exception, ExceptAddr, exception.Message);
 end;
 
-procedure TDUnitXTestRunner.ExecuteFixtures(const parentFixtureResult : IFixtureResult; const context: ITestExecuteContext; const threadId: Cardinal; const fixtures: ITestFixtureList);
+procedure TDUnitXTestRunner.ExecuteFixtures(const parentFixtureResult : IFixtureResult; const context: ITestExecuteContext; const threadId: TThreadID; const fixtures: ITestFixtureList);
 var
   fixture: ITestFixture;
   fixtureResult : IFixtureResult;
@@ -637,12 +637,12 @@ begin
   end;
 end;
 
-function TDUnitXTestRunner.ExecuteIgnoredResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const ignoreReason: string): ITestResult;
+function TDUnitXTestRunner.ExecuteIgnoredResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const ignoreReason: string): ITestResult;
 begin
   result := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.Ignored, ignoreReason);
 end;
 
-procedure TDUnitXTestRunner.ExecuteSetupFixtureMethod(const threadid: cardinal; const fixture : ITestFixture);
+procedure TDUnitXTestRunner.ExecuteSetupFixtureMethod(const threadId: TThreadID; const fixture : ITestFixture);
 begin
   try
     Self.Loggers_SetupFixture(threadid, fixture as ITestFixtureInfo);
@@ -659,12 +659,12 @@ begin
   end;
 end;
 
-function TDUnitXTestRunner.ExecuteSuccessfulResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const message: string) : ITestResult;
+function TDUnitXTestRunner.ExecuteSuccessfulResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const message: string) : ITestResult;
 begin
   Result := TDUnitXTestResult.Create(test as ITestInfo, TTestResultType.Pass, message);
 end;
 
-procedure TDUnitXTestRunner.ExecuteTearDownFixtureMethod(const context: ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture);
+procedure TDUnitXTestRunner.ExecuteTearDownFixtureMethod(const context: ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture);
 begin
   try
     Self.Loggers_TeardownFixture(threadId, fixture as ITestFixtureInfo);
@@ -680,7 +680,7 @@ begin
   end;
 end;
 
-function TDUnitXTestRunner.ExecuteTest(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const memoryAllocationProvider : IMemoryLeakMonitor) : ITestResult;
+function TDUnitXTestRunner.ExecuteTest(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const memoryAllocationProvider : IMemoryLeakMonitor) : ITestResult;
 var
   testExecute: ITestExecute;
   assertBeforeCount : Cardinal;
@@ -717,7 +717,7 @@ begin
   end;
 end;
 
-procedure TDUnitXTestRunner.ExecuteTests(const context : ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture; const fixtureResult : IFixtureResult);
+procedure TDUnitXTestRunner.ExecuteTests(const context : ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const fixtureResult : IFixtureResult);
 var
   tests : IEnumerable<ITest>;
   test : ITest;
@@ -789,7 +789,7 @@ begin
   end;
 end;
 
-function TDUnitXTestRunner.ExecuteTestSetupMethod(const context : ITestExecuteContext; const threadid: cardinal; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor): boolean;
+function TDUnitXTestRunner.ExecuteTestSetupMethod(const context : ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor): boolean;
 begin
   Result := False;
   errorResult := nil;
@@ -818,7 +818,7 @@ begin
 end;
 
 function TDUnitXTestRunner.ExecuteTestTearDown(const context:
-  ITestExecuteContext; const threadId: Cardinal; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor): boolean;
+  ITestExecuteContext; const threadId: TThreadID; const fixture: ITestFixture; const test: ITest; out errorResult: ITestResult; const memoryAllocationProvider : IMemoryLeakMonitor): boolean;
 begin
   Result := False;
   errorResult := nil;
@@ -843,7 +843,7 @@ end;
 
 
 
-function TDUnitXTestRunner.ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: cardinal; const test: ITest; const exception: Exception): ITestError;
+function TDUnitXTestRunner.ExecuteTimedOutResult(const context: ITestExecuteContext; const threadId: TThreadID; const test: ITest; const exception: Exception): ITestError;
 begin
   Result := TDUnitXTestError.Create(test as ITestInfo, TTestResultType.Failure, exception, ExceptAddr, exception.Message);
 end;
@@ -879,7 +879,7 @@ begin
   Self.Log(TLogLevel.Information,msg);
 end;
 
-procedure TDUnitXTestRunner.Loggers_SetupFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTestRunner.Loggers_SetupFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 var
   logger : ITestLogger;
 begin
@@ -887,7 +887,7 @@ begin
     logger.OnSetupFixture(threadId,fixture);
 end;
 
-procedure TDUnitXTestRunner.Loggers_SetupTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTestRunner.Loggers_SetupTest(const threadId: TThreadID; const Test: ITestInfo);
 var
   logger : ITestLogger;
 begin
@@ -895,7 +895,7 @@ begin
     logger.OnSetupTest(threadId,Test);
 end;
 
-procedure TDUnitXTestRunner.Loggers_BeginTest(const threadId : Cardinal; const Test: ITestInfo);
+procedure TDUnitXTestRunner.Loggers_BeginTest(const threadId: TThreadID; const Test: ITestInfo);
 var
   logger : ITestLogger;
 begin
@@ -903,7 +903,7 @@ begin
     logger.OnBeginTest(threadId, Test);
 end;
 
-procedure TDUnitXTestRunner.Loggers_StartTestFixture(const threadId : Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTestRunner.Loggers_StartTestFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 var
   logger : ITestLogger;
 begin
@@ -911,7 +911,7 @@ begin
     logger.OnStartTestFixture(threadId, fixture);
 end;
 
-procedure TDUnitXTestRunner.Loggers_TeardownFixture(const threadId: Cardinal; const fixture: ITestFixtureInfo);
+procedure TDUnitXTestRunner.Loggers_TeardownFixture(const threadId: TThreadID; const fixture: ITestFixtureInfo);
 var
   logger : ITestLogger;
 begin
@@ -919,7 +919,7 @@ begin
     logger.OnTearDownFixture(threadId, fixture);
 end;
 
-procedure TDUnitXTestRunner.Loggers_TeardownTest(const threadId: Cardinal; const Test: ITestInfo);
+procedure TDUnitXTestRunner.Loggers_TeardownTest(const threadId: TThreadID; const Test: ITestInfo);
 var
   logger : ITestLogger;
 begin
@@ -935,7 +935,7 @@ begin
     logger.OnTestingEnds(RunResults);
 end;
 
-procedure TDUnitXTestRunner.Loggers_TestingStarts(const threadId, testCount, testActiveCount : Cardinal);
+procedure TDUnitXTestRunner.Loggers_TestingStarts(const threadId: TThreadID; testCount, testActiveCount: Cardinal);
 var
   logger : ITestLogger;
 begin

--- a/DUnitX.Timeout.pas
+++ b/DUnitX.Timeout.pas
@@ -83,7 +83,7 @@ begin
   FTimeoutThread.FreeOnTerminate := false;
   FTimeoutThread.ThreadHandle := AThreadHandle;
   FTimeoutThread.Timeout := ATimeout;
-  FTimeoutThread.Resume;
+  FTimeoutThread.Start;
 end;
 
 destructor TTimeout.Destroy;
@@ -99,14 +99,14 @@ end;
 
 procedure TTimeoutThread.Execute;
 var
-  I: Integer;
   startTime : Cardinal;
-  elaspedTime : Cardinal;
+  elapsedTime : Cardinal;
 begin
   inherited;
 
   //Get the tickcount so that we leave timing up to the system.
   startTime := GetTickCount;
+  elapsedTime := 0;
 
   repeat
     //Give some time back to the system to process the test.
@@ -115,8 +115,8 @@ begin
     if Terminated then
       Break;
 
-    elaspedTime := GetElapsedTime(startTime);
-  until (elaspedTime >= Timeout);
+    elapsedTime := GetElapsedTime(startTime);
+  until (elapsedTime >= Timeout);
 
   //If we haven't been terminated then we have timed out.
   if not Terminated then


### PR DESCRIPTION
Removing const on the 2 Cardinal parameters in the method OnTestingStarts was done on purpose because that is how Embarcadero changed it and unfortunately thus introduced a breaking change. 

Since fixing this in this repository is done quicker and can be done without causing any harm I decided to do so in order to properly support DUnitX with TestInsight.

Additionally fixed some compiler messages.