### PR TITLE
Erros de compilação.

### DIFF
--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -43,7 +43,7 @@ uses
 
 type
   TDUnitXTestFixture = class(TWeakReferencedObject, ITestFixture,ITestFixtureInfo)
-  class var
+  private class var
     FRttiContext  : TRttiContext;
   private
     FTestClass    : TClass;

--- a/DUnitX.Utils.pas
+++ b/DUnitX.Utils.pas
@@ -77,6 +77,7 @@ type
   TCustomAttributeClass = class of TCustomAttribute;
 
   TAttributeUtils = class
+  public
     class function ContainsAttribute(const attributes : TArray<TCustomAttribute>; const AttributeClass : TCustomAttributeClass) : boolean;
     class function FindAttribute(const attributes : TArray<TCustomAttribute>; const AttributeClass : TCustomAttributeClass) : TCustomAttribute;overload;
     class function FindAttribute(const attributes : TArray<TCustomAttribute>; const AttributeClass : TCustomAttributeClass; var attribute  : TCustomAttribute; const startIndex : integer = 0) : integer;overload;


### PR DESCRIPTION
Ajustado erros de compilação quando era ativado o "Emit runtime type information".