### PR TITLE
Erro de compilação

### DIFF
--- a/DUnitX.Utils.pas
+++ b/DUnitX.Utils.pas
@@ -2963,6 +2963,7 @@ end;
 type
  // Declare compatible members of TRttiObject in System.Rtti.pas
   TRttiObjectFieldRef = class abstract
+  public
     FHandle: Pointer;
     FRttiDataSize: Integer;
     FPackage: Pointer{TRttiPackage};


### PR DESCRIPTION
A classe TRttiObjectFieldRef, está sem a definição de escopo dos campos da classe, com isso está dando erro de compilação quando o "Emit Runtime Type Information" estiver marcado no projeto.

Apenas coloquei a declaração "public" para parar de dar erro.
