### PR TITLE
Enforcing Windows CRLF for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,13 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text eol=crlf
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
-*.pas text
-*.dfm text
 
 # Declare files that will always have CRLF line endings on checkout.
 
 # Denote all files that are truly binary and should not be modified.
 *.exe binary
 *.res binary
+*.dres binary
+*.ico binary


### PR DESCRIPTION
Per the instructions here:
https://help.github.com/articles/dealing-with-line-endings/

Changing the gitattributes file does not affect the current files (thus
no other file touches are required) but should enforce CRLF as
contributors work on files from this commit forward.