### PR TITLE
Replace `DUNITX-DEBUG` in `.dproj` files with  `DUNITXDEBUG`

### DIFF
--- a/Examples/DUnitXExamples_D10Berlin.dproj
+++ b/Examples/DUnitXExamples_D10Berlin.dproj
@@ -98,7 +98,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_DebugInformation>1</DCC_DebugInformation>
-        <DCC_Define>DUNITX-DEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>

--- a/Examples/DUnitXExamples_D10Seattle.dproj
+++ b/Examples/DUnitXExamples_D10Seattle.dproj
@@ -224,7 +224,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_DebugInformation>1</DCC_DebugInformation>
-        <DCC_Define>DUNITX-DEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>

--- a/Examples/DUnitXExamples_XE2.dproj
+++ b/Examples/DUnitXExamples_XE2.dproj
@@ -98,7 +98,7 @@
 			<VerInfo_Locale>1033</VerInfo_Locale>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-			<DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+			<DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
 			<VerInfo_Locale>1033</VerInfo_Locale>
 		</PropertyGroup>
 		<ItemGroup>

--- a/Examples/DUnitXExamples_XE7.dproj
+++ b/Examples/DUnitXExamples_XE7.dproj
@@ -96,7 +96,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_DebugInformation>1</DCC_DebugInformation>
-        <DCC_Define>DUNITX-DEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>

--- a/Examples/DUnitXExamples_XE8.dproj
+++ b/Examples/DUnitXExamples_XE8.dproj
@@ -96,7 +96,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <DCC_DebugInformation>1</DCC_DebugInformation>
-        <DCC_Define>DUNITX-DEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>

--- a/Tests/DUnitXTest_D10Berlin.dproj
+++ b/Tests/DUnitXTest_D10Berlin.dproj
@@ -66,7 +66,7 @@
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/Tests/DUnitXTest_D10Seattle.dproj
+++ b/Tests/DUnitXTest_D10Seattle.dproj
@@ -192,7 +192,7 @@
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/Tests/DUnitXTest_XE2.dproj
+++ b/Tests/DUnitXTest_XE2.dproj
@@ -63,7 +63,7 @@
 			<DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-			<DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+			<DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
 			<DCC_TypedAtParameter>true</DCC_TypedAtParameter>
 		</PropertyGroup>
 		<ItemGroup>

--- a/Tests/DUnitXTest_XE7.dproj
+++ b/Tests/DUnitXTest_XE7.dproj
@@ -64,7 +64,7 @@
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/Tests/DUnitXTest_XE8.dproj
+++ b/Tests/DUnitXTest_XE8.dproj
@@ -64,7 +64,7 @@
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
-        <DCC_Define>DUNITX-DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DUNITXDEBUG;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">


### PR DESCRIPTION
Replace `DUNITX-DEBUG` in `.dproj` files with  `DUNITXDEBUG` to keep `BRCC32.exe` happy when you add a .RC file to your project. Fixes #158