### PR TITLE
Correction to work with Delphi XE

### DIFF
--- a/DUnitX.AutoDetect.Console.pas
+++ b/DUnitX.AutoDetect.Console.pas
@@ -65,7 +65,7 @@ uses
      DUnitX.Linux.Console;
  {$ELSE}
      {$MESSAGE Error 'Unknown Platform for Console Writer'}
- {$ENDIF}
+ {$IFEND}
 
 implementation
 


### PR DESCRIPTION
Delphi XE compiler (used via MSBuild in ContinuaCI) is returning following error (non relevant text redacted):
{DelphiBinPath}\CodeGear.Delphi.Targets(188,5): error : E:\ContinuaCi\WorkSpace\Ws\10000\Source\DUnitX\DUnitX.AutoDetect.Console.pas(68) Error: E2029 $IFEND expected but $ENDIF found
{DelphiBinPath}\CodeGear.Delphi.Targets(188,5): error : E:\ContinuaCi\WorkSpace\Ws\10000\Source\DUnitX\DUnitX.Loggers.Console.pas(463) Fatal: F2063 Could not compile used unit 'DUnitX.AutoDetect.Console.pas'