### PR TITLE
extended the TestAttribute with "Expected" property

### DIFF
--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -200,7 +200,7 @@ type
     FExpectedException : ExceptClass;
     FExceptionInheritance: TExceptionInheritance;
   public
-    constructor Create(AExpectedException : ExceptClass; const AInheritance : TExceptionInheritance = exSame);
+    constructor Create(AExpectedException : ExceptClass; const AInheritance : TExceptionInheritance = exExact);
     property ExpectedException : ExceptClass read FExpectedException;
     property ExceptionInheritance : TExceptionInheritance read FExceptionInheritance;
   end;

--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -33,8 +33,10 @@ interface
 uses
   {$IFDEF USE_NS}
   System.Rtti,
+  System.SysUtils,
   {$ELSE}
   Rtti,
+  SysUtils,
   {$ENDIF}
   DUnitX.Types;
 
@@ -138,13 +140,13 @@ type
   TestAttribute = class(TCustomAttribute)
   private
     FEnabled : boolean;
-    FExpected: string;
+    FExpected: ExceptClass;
   public
     constructor Create;overload;
     constructor Create(const AEnabled : boolean);overload;
-    constructor Create(const AExpected: string; const AEnabled : boolean = true);overload;
+    constructor Create(AExpected: ExceptClass; const AEnabled : boolean = true);overload;
     property Enabled : boolean read FEnabled;
-    property Expected : string read FExpected;
+    property Expected : ExceptClass read FExpected;
   end;
 
   /// <summary>
@@ -314,10 +316,10 @@ constructor TestAttribute.Create(const AEnabled: boolean);
 begin
   inherited Create;
   FEnabled := AEnabled;
-  FExpected := '';
+  FExpected := nil;
 end;
 
-constructor TestAttribute.Create(const AExpected: string; const AEnabled: boolean);
+constructor TestAttribute.Create(AExpected: ExceptClass; const AEnabled: boolean);
 begin
   inherited Create;
   FExpected := AExpected;

--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -138,10 +138,13 @@ type
   TestAttribute = class(TCustomAttribute)
   private
     FEnabled : boolean;
+    FExpected: string;
   public
     constructor Create;overload;
     constructor Create(const AEnabled : boolean);overload;
+    constructor Create(const AExpected: string; const AEnabled : boolean = true);overload;
     property Enabled : boolean read FEnabled;
+    property Expected : string read FExpected;
   end;
 
   /// <summary>
@@ -310,6 +313,14 @@ end;
 constructor TestAttribute.Create(const AEnabled: boolean);
 begin
   inherited Create;
+  FEnabled := AEnabled;
+  FExpected := '';
+end;
+
+constructor TestAttribute.Create(const AExpected: string; const AEnabled: boolean);
+begin
+  inherited Create;
+  FExpected := AExpected;
   FEnabled := AEnabled;
 end;
 

--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -140,15 +140,10 @@ type
   TestAttribute = class(TCustomAttribute)
   private
     FEnabled : boolean;
-    FWillRaise : ExceptClass;
-    FWillRaiseDescendant: boolean;
   public
     constructor Create;overload;
     constructor Create(const AEnabled : boolean);overload;
-    constructor Create(AWillRaise : ExceptClass; const AWillRaiseDescendant: boolean = false; const AEnabled : boolean = true);overload;
     property Enabled : boolean read FEnabled;
-    property WillRaise : ExceptClass read FWillRaise;
-    property WillRaiseDescendant: boolean read FWillRaiseDescendant;
   end;
 
   /// <summary>
@@ -193,6 +188,22 @@ type
     property Count : Cardinal read FCount;
   end;
 
+  /// <summary>
+  ///   This attribute marks a method as a test method which will raise an exception.
+  /// </summary>
+  /// <remarks>
+  ///   If [WillRaise(ERangeError)] is used then the test will fail if it
+  ///   does not raise an ERangeError.
+  /// </remarks>
+  WillRaiseAttribute = class(TCustomAttribute)
+  private
+    FExpectedException : ExceptClass;
+    FExceptionInheritance: TExceptionInheritance;
+  public
+    constructor Create(AExpectedException : ExceptClass; const AInheritance : TExceptionInheritance = exSame);
+    property ExpectedException : ExceptClass read FExpectedException;
+    property ExceptionInheritance : TExceptionInheritance read FExceptionInheritance;
+  end;
 
   /// <summary>
   ///   Internal Structure used for those implementing CustomTestCase or
@@ -318,15 +329,6 @@ constructor TestAttribute.Create(const AEnabled: boolean);
 begin
   inherited Create;
   FEnabled := AEnabled;
-  FWillRaise := nil;
-end;
-
-constructor TestAttribute.Create(AWillRaise: ExceptClass; const AWillRaiseDescendant: boolean; const AEnabled: boolean);
-begin
-  inherited Create;
-  FWillRaise := AWillRaise;
-  FWillRaiseDescendant := AWillRaiseDescendant;
-  FEnabled := AEnabled;
 end;
 
 { CategoryAttribute }
@@ -390,6 +392,14 @@ end;
 constructor MaxTimeAttribute.Create(const AMaxTime : Cardinal);
 begin
   FMaxTime := AMaxTime;
+end;
+
+{ WillRaiseAttribute }
+
+constructor WillRaiseAttribute.Create(AExpectedException: ExceptClass; const AInheritance: TExceptionInheritance);
+begin
+  FExpectedException := AExpectedException;
+  FExceptionInheritance := AInheritance;
 end;
 
 end.

--- a/DUnitX.Attributes.pas
+++ b/DUnitX.Attributes.pas
@@ -140,13 +140,15 @@ type
   TestAttribute = class(TCustomAttribute)
   private
     FEnabled : boolean;
-    FExpected: ExceptClass;
+    FWillRaise : ExceptClass;
+    FWillRaiseDescendant: boolean;
   public
     constructor Create;overload;
     constructor Create(const AEnabled : boolean);overload;
-    constructor Create(AExpected: ExceptClass; const AEnabled : boolean = true);overload;
+    constructor Create(AWillRaise : ExceptClass; const AWillRaiseDescendant: boolean = false; const AEnabled : boolean = true);overload;
     property Enabled : boolean read FEnabled;
-    property Expected : ExceptClass read FExpected;
+    property WillRaise : ExceptClass read FWillRaise;
+    property WillRaiseDescendant: boolean read FWillRaiseDescendant;
   end;
 
   /// <summary>
@@ -316,13 +318,14 @@ constructor TestAttribute.Create(const AEnabled: boolean);
 begin
   inherited Create;
   FEnabled := AEnabled;
-  FExpected := nil;
+  FWillRaise := nil;
 end;
 
-constructor TestAttribute.Create(AExpected: ExceptClass; const AEnabled: boolean);
+constructor TestAttribute.Create(AWillRaise: ExceptClass; const AWillRaiseDescendant: boolean; const AEnabled: boolean);
 begin
   inherited Create;
-  FExpected := AExpected;
+  FWillRaise := AWillRaise;
+  FWillRaiseDescendant := AWillRaiseDescendant;
   FEnabled := AEnabled;
 end;
 

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -129,7 +129,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exSame) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exExact) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -35,10 +35,12 @@ uses
   System.TimeSpan,
   System.Rtti,
   System.Generics.Collections,
+  System.SysUtils,
   {$ELSE}
   TimeSpan,
   Rtti,
   Generics.Collections,
+  SysUtils,
   {$ENDIF}
   DUnitX.Types,
   DUnitX.Generics;
@@ -127,7 +129,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; const AExptected: String = '') : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExptected: ExceptClass = nil) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -127,7 +127,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; const AExptected: String = '') : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -129,7 +129,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExptected: ExceptClass = nil) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AWillRaise: ExceptClass = nil; const AWillRaiseDescendant: Boolean = false) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.Extensibility.pas
+++ b/DUnitX.Extensibility.pas
@@ -129,7 +129,7 @@ type
     procedure OnMethodExecuted(const AMethod : TTestMethod);
     function GetFixtureInstance : TObject;
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AWillRaise: ExceptClass = nil; const AWillRaiseDescendant: Boolean = false) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exSame) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -265,6 +265,7 @@ var
   ignoredTest     : boolean;
   ignoredReason   : string;
   maxTime         : cardinal;
+  expectedException : string;
 
   repeatCount: Cardinal;
   i: Integer;
@@ -312,6 +313,7 @@ begin
     repeatCount := 1;
     maxTimeAttrib := nil;
     maxTime := 0;
+    expectedException := '';
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;
@@ -391,6 +393,7 @@ begin
     if method.TryGetAttributeOfType<TestAttribute>(testAttrib) then
     begin
       testEnabled := testAttrib.Enabled;
+      expectedException := testAttrib.Expected;
       isTestMethod := true;
     end;
     {$IFDEF MSWINDOWS}
@@ -451,7 +454,7 @@ begin
     begin
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime);
+        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime, expectedException);
       end;
       continue;
     end;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -265,7 +265,8 @@ var
   ignoredTest     : boolean;
   ignoredReason   : string;
   maxTime         : cardinal;
-  expectedException : ExceptClass;
+  willRaise       : ExceptClass;
+  willRaiseDesc   : boolean;
 
   repeatCount: Cardinal;
   i: Integer;
@@ -313,7 +314,8 @@ begin
     repeatCount := 1;
     maxTimeAttrib := nil;
     maxTime := 0;
-    expectedException := nil;
+    willRaise := nil;
+    willRaiseDesc := false;
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;
@@ -393,7 +395,8 @@ begin
     if method.TryGetAttributeOfType<TestAttribute>(testAttrib) then
     begin
       testEnabled := testAttrib.Enabled;
-      expectedException := testAttrib.Expected;
+      willRaise := testAttrib.WillRaise;
+      willRaiseDesc := testAttrib.WillRaiseDescendant;
       isTestMethod := true;
     end;
     {$IFDEF MSWINDOWS}
@@ -454,7 +457,7 @@ begin
     begin
       for i := 1 to repeatCount do
       begin
-        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime, expectedException);
+        currentFixture.AddTest(method.Name, TTestMethod(meth), FormatTestName(method.Name, i, repeatCount), category, true, ignoredTest, ignoredReason, maxTime, willRaise, willRaiseDesc);
       end;
       continue;
     end;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -318,7 +318,7 @@ begin
     maxTimeAttrib := nil;
     maxTime := 0;
     willRaise := nil;
-    willRaiseInherit := exSame;
+    willRaiseInherit := exExact;
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;

--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -265,7 +265,7 @@ var
   ignoredTest     : boolean;
   ignoredReason   : string;
   maxTime         : cardinal;
-  expectedException : string;
+  expectedException : ExceptClass;
 
   repeatCount: Cardinal;
   i: Integer;
@@ -313,7 +313,7 @@ begin
     repeatCount := 1;
     maxTimeAttrib := nil;
     maxTime := 0;
-    expectedException := '';
+    expectedException := nil;
     currentFixture := fixture;
 
     meth.Code := method.CodeAddress;

--- a/DUnitX.Test.pas
+++ b/DUnitX.Test.pas
@@ -116,7 +116,7 @@ type
     constructor Create(const AFixture : ITestFixture; const AMethodName : string; const AName : string; const ACategory  : string;
                        const AMethod : TTestMethod; const AEnabled : boolean; const AIgnored : boolean = false;
                        const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0;
-                       AExpectedException : ExceptClass = nil; const AExceptionInheritance : TExceptionInheritance = exSame);
+                       AExpectedException : ExceptClass = nil; const AExceptionInheritance : TExceptionInheritance = exExact);
   end;
 
   TDUnitXTestCase = class(TDUnitXTest, ITestExecute)

--- a/DUnitX.Test.pas
+++ b/DUnitX.Test.pas
@@ -102,6 +102,16 @@ type
     destructor Destroy;override;
   end;
 
+  TDUnitXExceptionTest = class(TDUnitXTest, ITestExecute)
+  private
+    FExpectedException: string;
+  public
+    constructor Create(const AFixture : ITestFixture; const AMethodName : string; const AName : string; const ACategory  : string;
+                       const AMethod : TTestMethod; const AEnabled : boolean; const AIgnored : boolean = false;
+                       const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0; const AExpected : string = '');
+    procedure Execute(const context : ITestExecuteContext); override;
+  end;
+
   TDUnitXTestCase = class(TDUnitXTest, ITestExecute)
   private
     FCaseName : string;
@@ -376,6 +386,30 @@ procedure TDUnitXTestCase.UpdateInstance(const fixtureInstance: TObject);
 begin
   inherited;
   FInstance := fixtureInstance;
+end;
+
+{ TDUnitXExceptionTest }
+
+constructor TDUnitXExceptionTest.Create(const AFixture: ITestFixture;
+  const AMethodName, AName, ACategory: string; const AMethod: TTestMethod;
+  const AEnabled, AIgnored: boolean; const AIgnoreReason: string;
+  const AMaxTime: Cardinal; const AExpected: string);
+begin
+  inherited Create(AFixture, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime);
+  FExpectedException := AExpected;
+end;
+
+procedure TDUnitXExceptionTest.Execute(const context: ITestExecuteContext);
+begin
+  try
+    inherited Execute(context);
+    Assert.FailFmt('Exception %s expected.', [FExpectedException]);
+  except
+    on E: Exception do
+    begin
+      Assert.AreEqual(FExpectedException, E.ClassName);
+    end;
+  end;
 end;
 
 end.

--- a/DUnitX.Test.pas
+++ b/DUnitX.Test.pas
@@ -106,8 +106,8 @@ type
 
   TDUnitXExceptionTest = class(TDUnitXTest, ITestExecute)
   private
-    FExceptionClass : ExceptClass;
-    FWillRaiseDescendant : boolean;
+    FExpectedException : ExceptClass;
+    FExceptionInheritance : TExceptionInheritance;
     FRaiseContext : ITestExecuteContext;
   protected
     procedure RaiseMethod;
@@ -116,7 +116,7 @@ type
     constructor Create(const AFixture : ITestFixture; const AMethodName : string; const AName : string; const ACategory  : string;
                        const AMethod : TTestMethod; const AEnabled : boolean; const AIgnored : boolean = false;
                        const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0;
-                       AExceptionClass : ExceptClass = nil; const AWillRaiseDescendant : boolean = false);
+                       AExpectedException : ExceptClass = nil; const AExceptionInheritance : TExceptionInheritance = exSame);
   end;
 
   TDUnitXTestCase = class(TDUnitXTest, ITestExecute)
@@ -398,20 +398,20 @@ end;
 constructor TDUnitXExceptionTest.Create(const AFixture: ITestFixture;
   const AMethodName, AName, ACategory: string; const AMethod: TTestMethod;
   const AEnabled, AIgnored: boolean; const AIgnoreReason: string;
-  const AMaxTime: Cardinal; AExceptionClass: ExceptClass; const AWillRaiseDescendant: boolean);
+  const AMaxTime: Cardinal; AExpectedException: ExceptClass; const AExceptionInheritance: TExceptionInheritance);
 begin
   inherited Create(AFixture, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime);
-  FExceptionClass := AExceptionClass;
-  FWillRaiseDescendant := AWillRaiseDescendant;
+  FExpectedException := AExpectedException;
+  FExceptionInheritance := AExceptionInheritance;
 end;
 
 procedure TDUnitXExceptionTest.Execute(const context: ITestExecuteContext);
 begin
   FRaiseContext := context;
-  if FWillRaiseDescendant then
-    Assert.WillRaiseDescendant(RaiseMethod, FExceptionClass)
+  if FExceptionInheritance = exDescendant then
+    Assert.WillRaiseDescendant(RaiseMethod, FExpectedException)
   else
-    Assert.WillRaise(RaiseMethod, FExceptionClass);
+    Assert.WillRaise(RaiseMethod, FExpectedException);
 end;
 
 procedure TDUnitXExceptionTest.RaiseMethod;

--- a/DUnitX.Test.pas
+++ b/DUnitX.Test.pas
@@ -106,7 +106,8 @@ type
 
   TDUnitXExceptionTest = class(TDUnitXTest, ITestExecute)
   private
-    FExpectedException : ExceptClass;
+    FExceptionClass : ExceptClass;
+    FWillRaiseDescendant : boolean;
     FRaiseContext : ITestExecuteContext;
   protected
     procedure RaiseMethod;
@@ -114,7 +115,8 @@ type
   public
     constructor Create(const AFixture : ITestFixture; const AMethodName : string; const AName : string; const ACategory  : string;
                        const AMethod : TTestMethod; const AEnabled : boolean; const AIgnored : boolean = false;
-                       const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0; AExpected : ExceptClass = nil);
+                       const AIgnoreReason : string = ''; const AMaxTime : Cardinal = 0;
+                       AExceptionClass : ExceptClass = nil; const AWillRaiseDescendant : boolean = false);
   end;
 
   TDUnitXTestCase = class(TDUnitXTest, ITestExecute)
@@ -396,16 +398,20 @@ end;
 constructor TDUnitXExceptionTest.Create(const AFixture: ITestFixture;
   const AMethodName, AName, ACategory: string; const AMethod: TTestMethod;
   const AEnabled, AIgnored: boolean; const AIgnoreReason: string;
-  const AMaxTime: Cardinal; AExpected: ExceptClass);
+  const AMaxTime: Cardinal; AExceptionClass: ExceptClass; const AWillRaiseDescendant: boolean);
 begin
   inherited Create(AFixture, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime);
-  FExpectedException := AExpected;
+  FExceptionClass := AExceptionClass;
+  FWillRaiseDescendant := AWillRaiseDescendant;
 end;
 
 procedure TDUnitXExceptionTest.Execute(const context: ITestExecuteContext);
 begin
   FRaiseContext := context;
-  Assert.WillRaise(RaiseMethod, FExpectedException);
+  if FWillRaiseDescendant then
+    Assert.WillRaiseDescendant(RaiseMethod, FExceptionClass)
+  else
+    Assert.WillRaise(RaiseMethod, FExceptionClass);
 end;
 
 procedure TDUnitXExceptionTest.RaiseMethod;

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -34,9 +34,11 @@ uses
   {$IFDEF USE_NS}
   System.Generics.Collections,
   System.Rtti,
+  System.SysUtils,
   {$ELSE}
   Generics.Collections,
   Rtti,
+  SysUtils,
   {$ENDIF}
   DUnitX.Types,
   DUnitX.Attributes,
@@ -123,7 +125,7 @@ type
     procedure InitFixtureInstance;
     procedure InternalInitFixtureInstance(const isConstructing : boolean);
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; const AExpected : String = '') : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpected : ExceptClass = nil) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -148,11 +150,9 @@ implementation
 uses
   {$IFDEF USE_NS}
   System.TypInfo,
-  System.SysUtils,
   System.Generics.Defaults,
   {$ELSE}
   TypInfo,
-  SysUtils,
   Generics.Defaults,
   {$ENDIF}
   DUnitX.Test,
@@ -539,9 +539,9 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; const AExpected : String): ITest;
+function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; AExpected : ExceptClass): ITest;
 begin
-  if AExpected = '' then
+  if AExpected = nil then
     result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime)
   else
     result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AExpected);

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -125,7 +125,7 @@ type
     procedure InitFixtureInstance;
     procedure InternalInitFixtureInstance(const isConstructing : boolean);
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpected : ExceptClass = nil) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AWillRaise : ExceptClass = nil; const AWillRaiseDescendant : boolean = false) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -539,12 +539,12 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; AExpected : ExceptClass): ITest;
+function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; AWillRaise : ExceptClass; const AWillRaiseDescendant : boolean): ITest;
 begin
-  if AExpected = nil then
+  if AWillRaise = nil then
     result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime)
   else
-    result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AExpected);
+    result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AWillRaise, AWillRaiseDescendant);
   FTests.Add(Result);
 end;
 

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -125,7 +125,7 @@ type
     procedure InitFixtureInstance;
     procedure InternalInitFixtureInstance(const isConstructing : boolean);
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AWillRaise : ExceptClass = nil; const AWillRaiseDescendant : boolean = false) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exSame) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -539,12 +539,12 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; AWillRaise : ExceptClass; const AWillRaiseDescendant : boolean): ITest;
+function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; AExpectedException: ExceptClass; const AExceptionInheritance: TExceptionInheritance): ITest;
 begin
-  if AWillRaise = nil then
+  if AExpectedException = nil then
     result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime)
   else
-    result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AWillRaise, AWillRaiseDescendant);
+    result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AExpectedException, AExceptionInheritance);
   FTests.Add(Result);
 end;
 

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -123,7 +123,7 @@ type
     procedure InitFixtureInstance;
     procedure InternalInitFixtureInstance(const isConstructing : boolean);
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; const AExpected : String = '') : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;
@@ -539,9 +539,12 @@ begin
   FChildren.Add(result);
 end;
 
-function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal): ITest;
+function TDUnitXTestFixture.AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean;const AIgnored : boolean; const AIgnoreReason : string; const AMaxTime :cardinal; const AExpected : String): ITest;
 begin
-  result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime);
+  if AExpected = '' then
+    result  := TDUnitXTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime)
+  else
+    result  := TDUnitXExceptionTest.Create(Self, AMethodName, AName, ACategory, AMethod, AEnabled, AIgnored, AIgnoreReason, AMaxTime, AExpected);
   FTests.Add(Result);
 end;
 

--- a/DUnitX.TestFixture.pas
+++ b/DUnitX.TestFixture.pas
@@ -125,7 +125,7 @@ type
     procedure InitFixtureInstance;
     procedure InternalInitFixtureInstance(const isConstructing : boolean);
 
-    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exSame) : ITest;
+    function AddTest(const AMethodName : string; const AMethod : TTestMethod; const AName : string; const ACategory  : string; const AEnabled : boolean = true;const AIgnored : boolean = false; const AIgnoreReason : string = ''; const AMaxTime :cardinal = 0; AExpectedException: ExceptClass = nil; const AExceptionInheritance: TExceptionInheritance = exExact) : ITest;
     function AddTestCase(const AMethodName : string; const ACaseName : string; const AName : string; const ACategory  : string; const AMethod : TRttiMethod; const AEnabled : boolean; const AArgs : TValueArray) : ITest;
 
     function AddChildFixture(const ATestClass : TClass; const AName : string; const ACategory : string) : ITestFixture;overload;

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -59,7 +59,8 @@ uses
   DUnitX.Extensibility,
   DUnitX.Filters,
   DUnitX.ComparableFormat,
-  DUnitX.Exceptions;
+  DUnitX.Exceptions,
+  DUnitX.Types;
 
 {$HPPEMIT '#if defined(USEPACKAGES)'}
 {$HPPEMIT '# pragma comment(lib, "DUnitXRuntime.bpi")'}
@@ -81,12 +82,15 @@ type
   IgnoreAttribute = DUnitX.Attributes.IgnoreAttribute;
   RepeatTestAttribute = DUnitX.Attributes.RepeatTestAttribute;
   MaxTimeAttribute =  DUnitX.Attributes.MaxTimeAttribute;
+  WillRaiseAttribute = DUnitX.Attributes.WillRaiseAttribute;
   TestCaseInfo = DUnitX.Attributes.TestCaseInfo;
   TestCaseInfoArray = DUnitX.Attributes.TestCaseInfoArray;
 
   CustomTestCaseAttribute = DUnitX.Attributes.CustomTestCaseAttribute;
   CustomTestCaseSourceAttribute = DUnitX.Attributes.CustomTestCaseSourceAttribute;
   TestCaseAttribute = DUnitX.Attributes.TestCaseAttribute;
+
+  TExceptionInheritance = DUnitX.Types.TExceptionInheritance;
 
   TTestMethod = DUnitX.Extensibility.TTestMethod;
 
@@ -109,6 +113,9 @@ type
 
 const
   TLogLevelDesc : array[TLogLevel] of string = ('Info', 'Warn', 'Err');
+
+  exSame = DUnitX.Types.exSame;
+  exDescendant = DUnitX.Types.exDescendant;
 
 type
 {$IFDEF DELPHI_XE2_UP}

--- a/DUnitX.TestFramework.pas
+++ b/DUnitX.TestFramework.pas
@@ -114,7 +114,7 @@ type
 const
   TLogLevelDesc : array[TLogLevel] of string = ('Info', 'Warn', 'Err');
 
-  exSame = DUnitX.Types.exSame;
+  exExact = DUnitX.Types.exExact;
   exDescendant = DUnitX.Types.exDescendant;
 
 type

--- a/DUnitX.Types.pas
+++ b/DUnitX.Types.pas
@@ -48,7 +48,7 @@ type
   TValueArray = array of TValue;
   {$ENDIF}
 
-  TExceptionInheritance = (exSame, exDescendant);
+  TExceptionInheritance = (exExact, exDescendant);
 
 implementation
 

--- a/DUnitX.Types.pas
+++ b/DUnitX.Types.pas
@@ -48,7 +48,7 @@ type
   TValueArray = array of TValue;
   {$ENDIF}
 
-
+  TExceptionInheritance = (exSame, exDescendant);
 
 implementation
 

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -31,8 +31,12 @@ interface
 {$I DUnitX.inc}
 
 uses
-  DUnitX.TestFramework;
-
+  DUnitX.TestFramework,
+  {$IFDEF USE_NS}
+  System.SysUtils;
+  {$ELSE}
+  SysUtils;
+  {$ENDIF}
 
 type
   {$M+}
@@ -77,7 +81,7 @@ type
     [Ignore('I was told to ignore me')]
     procedure IgnoreMe;
 
-    [Test('EOutOfMemory')]
+    [Test(EOutOfMemory)]
     procedure FailMe;
 
     [Setup]
@@ -130,11 +134,6 @@ type
 implementation
 
 uses
-  {$IFDEF USE_NS}
-  System.SysUtils,
-  {$ELSE}
-  SysUtils,
-  {$ENDIF}
   DUnitX.DUnitCompatibility;
 
 { TMyExampleTests }

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -77,6 +77,9 @@ type
     [Ignore('I was told to ignore me')]
     procedure IgnoreMe;
 
+    [Test('EOutOfMemory')]
+    procedure FailMe;
+
     [Setup]
     procedure Setup;
 
@@ -141,6 +144,11 @@ procedure TMyExampleTests.DontCallMe;
 begin
   TDUnitX.CurrentRunner.Status('DontCallMe called');
   raise Exception.Create('DontCallMe was called!!!!');
+end;
+
+procedure TMyExampleTests.FailMe;
+begin
+  OutOfMemoryError;
 end;
 
 procedure TMyExampleTests.IgnoreMe;

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -81,14 +81,18 @@ type
     [Ignore('I was told to ignore me')]
     procedure IgnoreMe;
 
-    [Test(EOutOfMemory)]
+    [WillRaise(EOutOfMemory)]
     procedure FailMe;
 
-    [Test(EHeapException, true)]
+    [WillRaise(EHeapException, exDescendant)]
     procedure FailMeToo;
 
-    [Test(Exception, true)]
+    [WillRaise(Exception, exDescendant)]
     procedure FailAny;
+
+    [WillRaise(EOutOfMemory)]
+    [Ignore('I am not behaving as I should')]
+    procedure IgnoreMeCauseImWrong;
 
     [Setup]
     procedure Setup;
@@ -174,6 +178,11 @@ end;
 procedure TMyExampleTests.IgnoreMeAnyway;
 begin
   Assert.IsTrue(false,'I should not have been called!');
+end;
+
+procedure TMyExampleTests.IgnoreMeCauseImWrong;
+begin
+  Abort;
 end;
 
 procedure TMyExampleTests.Setup;

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -84,6 +84,12 @@ type
     [Test(EOutOfMemory)]
     procedure FailMe;
 
+    [Test(EHeapException, true)]
+    procedure FailMeToo;
+
+    [Test(Exception, true)]
+    procedure FailAny;
+
     [Setup]
     procedure Setup;
 
@@ -145,7 +151,17 @@ begin
   raise Exception.Create('DontCallMe was called!!!!');
 end;
 
+procedure TMyExampleTests.FailAny;
+begin
+  Abort;
+end;
+
 procedure TMyExampleTests.FailMe;
+begin
+  OutOfMemoryError;
+end;
+
+procedure TMyExampleTests.FailMeToo;
 begin
   OutOfMemoryError;
 end;


### PR DESCRIPTION
like in JUnit the _expected_ attribute allows you to verify that your code throws a specific exception.

Example:
```
[Test('EOutOfMemory')]
procedure FailMe;

procedure TMyTest.FailMe;
begin
  OutOfMemoryError;
end;
```