### PR TITLE
Add Delphinus support

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,11 @@
+{
+  "id": "{578B7A11-D6C6-468D-8C4F-BC822BA313A8}",
+  "name": "DUnitX",
+  "license_type": "Apache 2.0",
+  "license_file": "LICENSE.txt",
+  "platforms": "Win32;Win64",
+  "package_compiler_min": 21,
+  "package_compiler_max": 32,
+  "compiler_min": 21,
+  "compiler_max": 32
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,85 @@
+{
+  "search_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "browsing_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "source_folders": [{
+    "folder": "."
+  },
+  {
+    "folder": "Build",
+    "recursive": true
+  },
+  {
+    "folder": "Examples",
+    "recursive": true
+  },
+  {
+    "folder": "Expert",
+    "recursive": true
+  },
+  {
+    "folder": "Images",
+    "recursive": true
+  },
+  {
+    "folder": "LiveTemplates",
+    "recursive": true
+  },
+  {
+    "folder": "Tests",
+    "recursive": true
+  }],
+  "projects": [{
+    "project": "Expert\\DUnitX_2010.dproj",
+    "compiler": 21
+  },
+  {
+    "project": "Expert\\DUnitX_XE.dproj",
+    "compiler": 22
+  },
+  {
+    "project": "Expert\\DUnitX_XE2.dproj",
+    "compiler": 23
+  },
+  {
+    "project": "Expert\\DUnitX_XE3.dproj",
+    "compiler": 24
+  },
+  {
+    "project": "Expert\\DUnitX_XE4.dproj",
+    "compiler": 25
+  },
+  {
+    "project": "Expert\\DUnitX_XE5.dproj",
+    "compiler": 26
+  },
+  {
+    "project": "Expert\\DUnitX_XE6.dproj",
+    "compiler": 27
+  },
+  {
+    "project": "Expert\\DUnitX_XE7.dproj",
+    "compiler": 28
+  },
+  {
+    "project": "Expert\\DUnitX_XE8.dproj",
+    "compiler": 29
+  },
+  {
+    "project": "Expert\\DUnitX_D10Seattle.dproj",
+    "compiler": 30
+  },
+  {
+    "project": "Expert\\DUnitX_D10Berlin.dproj",
+    "compiler": 31
+  },
+  {
+    "project": "Expert\\DUnitX_IDE_Expert_D10Tokyo.dproj",
+    "compiler": 32
+  }]
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is far from a complete list, but a few planned features are listed here to 
 Tips and Tricks
 ===========
 * In order to workaround the [Delphi XE3 Bug](https://github.com/VSoftTechnologies/DUnitX/issues/117), you need to add the unit DUnitX.Init to your test projects.
+* If you have Delphi XE or newer, you can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install DUnitX there. (Delphinus-Support)
 
 Support
 =======


### PR DESCRIPTION
It's a little idea to consider.
Maybe the whole Delphinus project (https://github.com/Memnarch/Delphinus) is not so mature but I think it's just nice idea because it can work directly with GitHub (in opposite to GetIt).

Why?
1) DunitX is not included in Delphi 10.1 / 10.2 Starter. I don't know why but it sucks.
2) To make DUnitX installation quick and easy. (user just clicks and the magic happens!)
3) To be able to add DUnitX as dependency for Delphinus packages.

There is a... uhm... tiny problem - tests have... circular reference with Delphi Mocks?! :roll_eyes: 
DUnitX Tests depends on Delphi Mocks and Delphi Mocks... depends on DUnitX base...
So installation generally works but can't execute any testing :cry: 

Oh... and the line with keyword "Delphinus-Support" in readme is needed to find DUnitX repository via GitHub API.

PS. I copied GUID from DUnitX files