### PR TITLE
Correct Error Message for Assert.InheritsFrom with two Classes

### DIFF
--- a/DUnitX.Assert.pas
+++ b/DUnitX.Assert.pas
@@ -715,7 +715,7 @@ begin
     if parent = nil then
       msg := msg + 'nil'
     else
-      msg := parent.ClassName + msg;
+      msg := msg + parent.ClassName;
     msg := msg + '.';
     if True then
     if message <> '' then


### PR DESCRIPTION
Hi there,

calling `Assert.InheritsFrom(TStringList, Exception)` will generate an error message like the following which looks ugly.

> TStringListException does not inherit from .

The proposed change alters the generation of said error message to look like this:

> TStringList does not inherit from Exception.

Regards.