### PR TITLE
AreEqual (Double and Extended overloads) did not check whether a value is NAN

### DIFF
--- a/DUnitX.Assert.pas
+++ b/DUnitX.Assert.pas
@@ -449,8 +449,13 @@ end;
 class procedure Assert.AreNotEqual(const expected, actual, tolerance: Extended; const message: string);
 begin
   DoAssert;
-  if {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected, actual, tolerance) then
-    FailFmt(SEqualsErrorExt ,[expected,actual,message], ReturnAddress);
+  if (IsNan(expected) and IsNan(actual)) then
+    FailFmt(SEqualsErrorExt ,[expected,actual,message], ReturnAddress)
+  else if not (IsNan(expected) xor IsNan(actual)) then
+  begin
+    if {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected, actual, tolerance) then
+      FailFmt(SEqualsErrorExt ,[expected,actual,message], ReturnAddress);
+  end;
 end;
 
 class procedure Assert.AreNotEqual(const expected, actual: string;const ignoreCase: boolean; const message: string);
@@ -538,8 +543,13 @@ end;
 class procedure Assert.AreNotEqual(const expected, actual, tolerance: double; const message: string);
 begin
   DoAssert;
-  if {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected, actual, tolerance) then
-    FailFmt(SEqualsErrorDbl ,[expected,actual,message], ReturnAddress);
+  if (IsNan(expected) and IsNan(actual)) then
+    FailFmt(SEqualsErrorExt ,[expected,actual,message], ReturnAddress)
+  else if not (IsNan(expected) xor IsNan(actual)) then
+  begin
+    if {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected, actual, tolerance) then
+      FailFmt(SEqualsErrorDbl ,[expected,actual,message], ReturnAddress);
+  end;
 end;
 
 class procedure Assert.AreNotEqualMemory(const expected, actual: Pointer; const size: Cardinal; const message: string);

--- a/DUnitX.Assert.pas
+++ b/DUnitX.Assert.pas
@@ -338,7 +338,8 @@ end;
 class procedure Assert.AreEqual(const expected, actual, tolerance: Extended; const message: string);
 begin
   DoAssert;
-  if not {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected,actual,tolerance) then
+  if (IsNan(expected) xor IsNan(actual)) or
+      not {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected,actual,tolerance) then
     FailFmt(SUnexpectedErrorExt ,[expected,actual,message], ReturnAddress);
 end;
 
@@ -417,7 +418,8 @@ end;
 class procedure Assert.AreEqual(const expected, actual, tolerance: Double; const message: string);
 begin
   DoAssert;
-  if not {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected,actual,tolerance) then
+  if (IsNan(expected) xor IsNan(actual)) or
+      not {$IFDEF USE_NS}System.Math.{$ENDIF}SameValue(expected,actual,tolerance) then
     FailFmt(SUnexpectedErrorDbl ,[expected,actual,message], ReturnAddress);
 end;
 

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -721,6 +721,7 @@ const
   ACTUAL_DOUBLE : double = 1.19E20;
   EXPECTED_DOUBLE : double = 1.18E20;
   TOLERANCE_DOUBLE : double = 0.001E20;
+  NOT_A_NUMBER_DOUBLE : double = 0/0;
 begin
   Assert.WillRaise(
     procedure
@@ -731,7 +732,7 @@ begin
   Assert.WillRaise(
     procedure
     begin
-      Assert.AreEqual(Double(0/0), EXPECTED_DOUBLE, TOLERANCE_DOUBLE);
+      Assert.AreEqual(NOT_A_NUMBER_DOUBLE, EXPECTED_DOUBLE, TOLERANCE_DOUBLE);
     end, ETestFailure, Format('[%e] with in [%e] from [%e]', [ACTUAL_DOUBLE, TOLERANCE_DOUBLE, EXPECTED_DOUBLE]));
 end;
 
@@ -753,6 +754,7 @@ const
   ACTUAL_EXTENDED : extended  = 1.19E20;
   EXPECTED_EXTENDED : extended = 1.18E20;
   TOLERANCE_EXTENDED : extended = 0.001E20;
+  NOT_A_NUMBER_EXTENDED : extended = 0/0;
 begin
   Assert.WillRaise(
     procedure
@@ -763,7 +765,7 @@ begin
   Assert.WillRaise(
     procedure
     begin
-      Assert.AreEqual(Extended(0/0), EXPECTED_EXTENDED, TOLERANCE_EXTENDED);
+      Assert.AreEqual(NOT_A_NUMBER_EXTENDED, EXPECTED_EXTENDED, TOLERANCE_EXTENDED);
     end, ETestFailure, Format('[%e] with in [%e] from [%e]', [ACTUAL_EXTENDED, TOLERANCE_EXTENDED, EXPECTED_EXTENDED]));
 end;
 
@@ -1080,6 +1082,8 @@ end;
 procedure TTestsAssert.AreNotEqual_Extended_One_Value_Is_Nan_FPExcept_Disabled;
 const
   TOLERANCE_EXTENDED : extended = 0.011E20;
+  EXPECTED_EXTENDED : extended = 100;
+  NOT_A_NUMBER_EXTENDED : extended = 0/0;
 begin
   // Let's assume we're in a OpenGL application... from System.Set8087CW online help:
   // [...] When using OpenGL to render 3D graphics, we recommend that you
@@ -1091,13 +1095,13 @@ begin
   Set8087CW($133F);
 
   // operations here will not raise any exceptions
-  Assert.AreNotEqual(Extended(100), Extended(0/0), Extended(TOLERANCE_EXTENDED));
+  Assert.AreNotEqual(EXPECTED_EXTENDED, NOT_A_NUMBER_EXTENDED, TOLERANCE_EXTENDED);
 
   Assert.WillRaise(
       procedure
       begin
         // intentionally failing this test to check whether a fail is detected
-        Assert.AreNotEqual(Extended(0/0), Extended(0/0), Extended(TOLERANCE_EXTENDED));
+        Assert.AreNotEqual(NOT_A_NUMBER_EXTENDED, NOT_A_NUMBER_EXTENDED, TOLERANCE_EXTENDED);
       end,
       ETestFailure);
 
@@ -1108,6 +1112,8 @@ end;
 procedure TTestsAssert.AreNotEqual_Double_One_Value_Is_Nan_FPExcept_Disabled;
 const
   TOLERANCE_DOUBLE : double  = 0.011E20;
+  NOT_A_NUMBER_DOUBLE : double = 0/0;
+  EXPECTED_DOUBLE : double = 100;
 begin
   // Let's assume we're in a OpenGL application... from System.Set8087CW online help:
   // [...] When using OpenGL to render 3D graphics, we recommend that you
@@ -1119,13 +1125,13 @@ begin
   Set8087CW($133F);
 
   // operations here will not raise any exceptions
-  Assert.AreNotEqual(Double(100), Double(0/0), Double(TOLERANCE_DOUBLE));
+  Assert.AreNotEqual(EXPECTED_DOUBLE, NOT_A_NUMBER_DOUBLE, TOLERANCE_DOUBLE);
 
   Assert.WillRaise(
       procedure
       begin
         // intentionally failing this test to check whether a fail is detected
-        Assert.AreNotEqual(Double(0/0), Double(0/0), Double(TOLERANCE_DOUBLE));
+        Assert.AreNotEqual(NOT_A_NUMBER_DOUBLE, NOT_A_NUMBER_DOUBLE, TOLERANCE_DOUBLE);
       end,
       ETestFailure);
 


### PR DESCRIPTION
If one of the values (actual or expected) passed to the method is Nan, then the framework did not check this situation, delegating SomeValue to provide a result.
As consequence the result may be random, since SameValue (neither AreEqual) checks the presence of a Nan value.
In my case I got that -Nan is equal to expected 100.