### PR TITLE
fixing wrong var passed into FormatTestName

### DIFF
--- a/DUnitX.FixtureProviderPlugin.pas
+++ b/DUnitX.FixtureProviderPlugin.pas
@@ -462,7 +462,7 @@ begin
                 params := iProvider.GetCaseParams(method.name,x);
                 for i := 1 to repeatCount do
                 begin
-                  currentFixture.AddTestCase(method.Name, FormatCaseName(caseName,x), FormatTestName(method.Name, x, repeatCount), category, method, testEnabled, params);
+                  currentFixture.AddTestCase(method.Name, FormatCaseName(caseName,x), FormatTestName(method.Name, i, repeatCount), category, method, testEnabled, params);
                 end;
               end;
               iProvider := nil;


### PR DESCRIPTION
I think that "i" was intended instead of "x" when calling FormatTestName here.