### PR TITLE
Test suite: remove reference to missing file DUnitX.CommandLine

### DIFF
--- a/Tests/DUnitXGuiTest.dpr
+++ b/Tests/DUnitXGuiTest.dpr
@@ -13,7 +13,6 @@ uses
   DUnitX.Generics in '..\DUnitX.Generics.pas',
   DUnitX.Utils in '..\DUnitX.Utils.pas',
   DUnitX.WeakReference in '..\DUnitX.WeakReference.pas',
-  DUnitX.CommandLine in '..\DUnitX.CommandLine.pas',
   DUnitX.Test in '..\DUnitX.Test.pas',
   DUnitX.TestFixture in '..\DUnitX.TestFixture.pas',
   DUnitX.TestResult in '..\DUnitX.TestResult.pas',


### PR DESCRIPTION
Probably some DUnitX.CommandLine.* units should be added... but the project compiles OK