### PR TITLE
TestDataProvider: Declaration of 'GetCaseName' differs from previous declaration

### DIFF
--- a/Tests/DUnitX.Tests.TestDataProvider.pas
+++ b/Tests/DUnitX.Tests.TestDataProvider.pas
@@ -24,7 +24,7 @@ type
     public
       Constructor Create;Override;
       function GetCaseCount(const methodName : string) : Integer; override;
-      function GetCaseName(const methodName : string) : string; override;
+      function GetCaseName(const methodName : string; const caseNumber : integer) : string; override;
       function GetCaseParams(const methodName : string ; const caseNumber : integer) : TValuearray; override;
       Destructor Destroy;override;
   End;
@@ -65,7 +65,7 @@ begin
   result := flist.count;
 end;
 
-function TSampleProvider.GetCaseName(const methodName : string) : string;
+function TSampleProvider.GetCaseName(const methodName : string; const caseNumber : integer) : string;
 begin
   result := '';
   if (Methodname = 'spTstAdd') then


### PR DESCRIPTION
I added the missing caseNumber parameter to the GetCaseName function to fix the test project.