### PR TITLE
JUnit XML logger (Gitlab CI compatibility)

### DIFF
--- a/Source/DUnitX.Loggers.XML.JUnit.pas
+++ b/Source/DUnitX.Loggers.XML.JUnit.pas
@@ -77,101 +77,12 @@ type
 implementation
 
 uses
+  DUnitX.Utils.XML,
   {$IFDEF USE_NS}
   System.TypInfo;
   {$ELSE}
   TypInfo;
   {$ENDIF}
-
-function IsValidXMLChar(wc: WideChar): Boolean;
-begin
-  case Word(wc) of
-    $0009, $000A, $000C, $000D,
-      $0020..$D7FF,
-      $E000..$FFFD, // Standard Unicode chars below $FFFF
-      $D800..$DBFF, // High surrogate of Unicode character  = $10000 - $10FFFF
-      $DC00..$DFFF: // Low surrogate of Unicode character  = $10000 - $10FFFF
-      result := True;
-  else
-    result := False;
-  end;
-end;
-
-function StripInvalidXML(const s: string): string;
-var
-  i, count: Integer;
-begin
-  {$IFNDEF NEXTGEN}
-  count := Length(s);
-  setLength(result, count);
-  for i := 1 to Count do // Iterate
-  begin
-    if IsValidXMLChar(WideChar(s[i])) then
-      result[i] := s[i]
-    else
-      result[i] := ' ';
-  end; // for}
-  {$ELSE}
-  count := s.Length;
-  SetLength(result, count);
-  for i := 0 to count - 1 do // Iterate
-  begin
-    if IsValidXMLChar(s.Chars[i]) then
-    begin
-      result := result.Remove(i, 1);
-      result := result.Insert(i, s.Chars[i]);
-    end
-    else
-    begin
-      result := result.Remove(i, 1);
-      result := result.Insert(i, s.Chars[i]);
-    end;
-  end; // for}
-  {$ENDIF}
-end;
-function EscapeForXML(const value: string; const isAttribute: boolean = True; const isCDATASection : Boolean = False): string;
-begin
-  result := StripInvalidXML(value);
-  {$IFNDEF NEXTGEN}
-  if isCDATASection  then
-  begin
-    Result := StringReplace(Result, ']]>', ']>',[rfReplaceAll]);
-    exit;
-  end;
-
-  //note we are avoiding replacing &amp; with &amp;amp; !!
-  Result := StringReplace(result, '&amp;', '[[-xy-amp--]]',[rfReplaceAll]);
-  Result := StringReplace(result, '&', '&amp;',[rfReplaceAll]);
-  Result := StringReplace(result, '[[-xy-amp--]]', '&amp;amp;',[rfReplaceAll]);
-  Result := StringReplace(result, '<', '&lt;',[rfReplaceAll]);
-  Result := StringReplace(result, '>', '&gt;',[rfReplaceAll]);
-
-  if isAttribute then
-  begin
-    Result := StringReplace(result, '''', '&#39;',[rfReplaceAll]);
-    Result := StringReplace(result, '"', '&quot;',[rfReplaceAll]);
-  end;
-  {$ELSE}
-  if isCDATASection  then
-  begin
-    Result := Result.Replace(']]>', ']>', [rfReplaceAll]);
-    exit;
-  end;
-
-  //note we are avoiding replacing &amp; with &amp;amp; !!
-  Result := Result.Replace('&amp;', '[[-xy-amp--]]',[rfReplaceAll]);
-  Result := Result.Replace('&', '&amp;',[rfReplaceAll]);
-  Result := Result.Replace('[[-xy-amp--]]', '&amp;amp;',[rfReplaceAll]);
-  Result := Result.Replace('<', '&lt;',[rfReplaceAll]);
-  Result := Result.Replace('>', '&gt;',[rfReplaceAll]);
-
-  if isAttribute then
-  begin
-    Result := Result.Replace('''', '&#39;',[rfReplaceAll]);
-    Result := Result.Replace('"', '&quot;',[rfReplaceAll]);
-  end;
-  {$ENDIF}
-end;
 
 { TDUnitXXMLJUnitLogger }
 

--- a/Source/DUnitX.Loggers.XML.JUnit.pas
+++ b/Source/DUnitX.Loggers.XML.JUnit.pas
@@ -1,0 +1,535 @@
+{***************************************************************************}
+{                                                                           }
+{           DUnitX                                                          }
+{                                                                           }
+{           Copyright (C) 2015 Vincent Parrett & Contributors               }
+{                                                                           }
+{           vincent@finalbuilder.com                                        }
+{           http://www.finalbuilder.com                                     }
+{                                                                           }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Licensed under the Apache License, Version 2.0 (the "License");          }
+{  you may not use this file except in compliance with the License.         }
+{  You may obtain a copy of the License at                                  }
+{                                                                           }
+{      http://www.apache.org/licenses/LICENSE-2.0                           }
+{                                                                           }
+{  Unless required by applicable law or agreed to in writing, software      }
+{  distributed under the License is distributed on an "AS IS" BASIS,        }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. }
+{  See the License for the specific language governing permissions and      }
+{  limitations under the License.                                           }
+{                                                                           }
+{***************************************************************************}
+
+unit DUnitX.Loggers.XML.JUnit;
+
+interface
+
+{$I DUnitX.inc}
+
+uses
+  {$IFDEF USE_NS}
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections,
+  {$ELSE}
+  Classes,
+  SysUtils,
+  Generics.Collections,
+  {$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.Loggers.Null;
+
+type
+  TDUnitXXMLJUnitLogger = class(TDUnitXNullLogger)
+  private
+    FOutputStream : TStream;
+    FOwnsStream   : boolean;
+    FIndent       : integer;
+    FFormatSettings : TFormatSettings;
+  protected
+    procedure Indent;
+    procedure Outdent;
+    procedure WriteXMLLine(const value : string);
+
+
+    procedure OnTestingEnds(const RunResults: IRunResults); override;
+
+    procedure WriteCategoryNodes(const ACategoryList: TList<string>);
+    procedure WriteFixtureResult(const fixtureResult : IFixtureResult);
+    procedure WriteTestResult(const testResult : ITestResult);
+
+    function Format(const Format: string; const Args: array of const): String;
+  public
+    constructor Create(const AOutputStream : TStream; const AOwnsStream : boolean = false);
+    destructor Destroy;override;
+  end;
+
+  TDUnitXXMLJUnitFileLogger = class(TDUnitXXMLJUnitLogger)
+  public
+    constructor Create(const AFilename: string = '');
+  end;
+
+
+implementation
+
+uses
+  {$IFDEF USE_NS}
+  System.TypInfo;
+  {$ELSE}
+  TypInfo;
+  {$ENDIF}
+
+function IsValidXMLChar(wc: WideChar): Boolean;
+begin
+  case Word(wc) of
+    $0009, $000A, $000C, $000D,
+      $0020..$D7FF,
+      $E000..$FFFD, // Standard Unicode chars below $FFFF
+      $D800..$DBFF, // High surrogate of Unicode character  = $10000 - $10FFFF
+      $DC00..$DFFF: // Low surrogate of Unicode character  = $10000 - $10FFFF
+      result := True;
+  else
+    result := False;
+  end;
+end;
+
+function StripInvalidXML(const s: string): string;
+var
+  i, count: Integer;
+begin
+  {$IFNDEF NEXTGEN}
+  count := Length(s);
+  setLength(result, count);
+  for i := 1 to Count do // Iterate
+  begin
+    if IsValidXMLChar(WideChar(s[i])) then
+      result[i] := s[i]
+    else
+      result[i] := ' ';
+  end; // for}
+  {$ELSE}
+  count := s.Length;
+  SetLength(result, count);
+  for i := 0 to count - 1 do // Iterate
+  begin
+    if IsValidXMLChar(s.Chars[i]) then
+    begin
+      result := result.Remove(i, 1);
+      result := result.Insert(i, s.Chars[i]);
+    end
+    else
+    begin
+      result := result.Remove(i, 1);
+      result := result.Insert(i, s.Chars[i]);
+    end;
+  end; // for}
+  {$ENDIF}
+end;
+function EscapeForXML(const value: string; const isAttribute: boolean = True; const isCDATASection : Boolean = False): string;
+begin
+  result := StripInvalidXML(value);
+  {$IFNDEF NEXTGEN}
+  if isCDATASection  then
+  begin
+    Result := StringReplace(Result, ']]>', ']>',[rfReplaceAll]);
+    exit;
+  end;
+
+  //note we are avoiding replacing &amp; with &amp;amp; !!
+  Result := StringReplace(result, '&amp;', '[[-xy-amp--]]',[rfReplaceAll]);
+  Result := StringReplace(result, '&', '&amp;',[rfReplaceAll]);
+  Result := StringReplace(result, '[[-xy-amp--]]', '&amp;amp;',[rfReplaceAll]);
+  Result := StringReplace(result, '<', '&lt;',[rfReplaceAll]);
+  Result := StringReplace(result, '>', '&gt;',[rfReplaceAll]);
+
+  if isAttribute then
+  begin
+    Result := StringReplace(result, '''', '&#39;',[rfReplaceAll]);
+    Result := StringReplace(result, '"', '&quot;',[rfReplaceAll]);
+  end;
+  {$ELSE}
+  if isCDATASection  then
+  begin
+    Result := Result.Replace(']]>', ']>', [rfReplaceAll]);
+    exit;
+  end;
+
+  //note we are avoiding replacing &amp; with &amp;amp; !!
+  Result := Result.Replace('&amp;', '[[-xy-amp--]]',[rfReplaceAll]);
+  Result := Result.Replace('&', '&amp;',[rfReplaceAll]);
+  Result := Result.Replace('[[-xy-amp--]]', '&amp;amp;',[rfReplaceAll]);
+  Result := Result.Replace('<', '&lt;',[rfReplaceAll]);
+  Result := Result.Replace('>', '&gt;',[rfReplaceAll]);
+
+  if isAttribute then
+  begin
+    Result := Result.Replace('''', '&#39;',[rfReplaceAll]);
+    Result := Result.Replace('"', '&quot;',[rfReplaceAll]);
+  end;
+  {$ENDIF}
+end;
+
+{ TDUnitXXMLJUnitLogger }
+
+constructor TDUnitXXMLJUnitLogger.Create(const AOutputStream: TStream; const AOwnsStream : boolean = false);
+var
+  preamble: TBytes;
+  {$IFNDEF DELPHI_XE_UP}
+  oldThousandSeparator: Char;
+  oldDecimalSeparator: Char;
+  {$ENDIF}
+begin
+  inherited Create;
+  {$IFDEF DELPHI_XE_UP }
+  FFormatSettings := TFormatSettings.Create;
+  FFormatSettings.ThousandSeparator := ',';
+  FFormatSettings.DecimalSeparator := '.';
+  {$ELSE}
+  oldThousandSeparator        := {$IFDEF USE_NS}System.{$ENDIF}SysUtils.ThousandSeparator;
+  oldDecimalSeparator         := {$IFDEF USE_NS}System.{$ENDIF}DecimalSeparator;
+  try
+    SysUtils.ThousandSeparator := ',';
+    SysUtils.DecimalSeparator := '.';
+  {$ENDIF}
+  FOutputStream := AOutputStream;
+  FOwnsStream   := AOwnsStream;
+
+  Preamble := TEncoding.UTF8.GetPreamble;
+  FOutputStream.WriteBuffer(preamble[0], Length(preamble));
+  {$IFNDEF DELPHI_XE_UP}
+  finally
+    {$IFDEF USE_NS}System.{$ENDIF}SysUtils.ThousandSeparator := oldThousandSeparator;
+    {$IFDEF USE_NS}System.{$ENDIF}SysUtils.DecimalSeparator  := oldDecimalSeparator;
+  end;
+  {$ENDIF}
+
+end;
+
+destructor TDUnitXXMLJUnitLogger.Destroy;
+begin
+  if FOwnsStream then
+    FOutputStream.Free;
+  inherited;
+end;
+
+function TDUnitXXMLJUnitLogger.Format(const Format: string; const Args: array of const): String;
+begin
+  Result := {$IFDEF USE_NS}System.{$ENDIF}SysUtils.Format(Format, Args, FFormatSettings);
+end;
+
+procedure TDUnitXXMLJUnitLogger.Indent;
+begin
+  Inc(FIndent,2);
+end;
+
+procedure TDUnitXXMLJUnitLogger.OnTestingEnds(const RunResults: IRunResults);
+
+
+procedure LogFixture(const fixture : IFixtureResult; level : integer);
+var
+  child : IFixtureResult;
+  sLevel : string;
+begin
+  sLevel := StringOfChar(' ', level * 2 );
+  System.WriteLn(sLevel + fixture.Fixture.NameSpace + ':' + fixture.Fixture.Name + Format(' [Tests: %d] [Children: %d] [Passed : %d]',[fixture.ResultCount,fixture.ChildCount,fixture.PassCount]));
+
+  Inc(level);
+  for child in fixture.Children do
+  begin
+    LogFixture(child,level);
+  end;
+
+end;
+
+
+var
+  fixtureRes  : IFixtureResult;
+  sExeName    : string;
+  sResult     : string;
+  sTime       : string;
+  sDate       : string;
+  totalTests  : integer;
+begin
+
+{ first things first, rollup the namespaces.
+  So, where parent fixtures have no tests, or only one child fixture, combine into a single fixture.
+  }
+  for fixtureRes in RunResults.FixtureResults do
+  begin
+    fixtureRes.Reduce;
+//    LogFixture(fixtureRes,0);
+  end;
+
+  //JUnit reports the total without the Ignored.
+  totalTests := RunResults.TestCount - RunResults.IgnoredCount;
+
+  sExeName := ParamStr(0);
+  FIndent := 0;
+  sTime := Format('%.3f',[RunResults.Duration.TotalSeconds]);
+  sDate := FormatDateTime('yyyy-MM-dd',RunResults.StartTime);
+
+  WriteXMLLine('<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>');
+  WriteXMLLine(Format('<test-results name="%s" total="%d" errors="%d" failures="%d" ignored="%d" inconclusive="0" not-run="%d" skipped="0" invalid="0" date="%s" time="%s">',
+                      [sExeName,totalTests,RunResults.ErrorCount,RunResults.FailureCount,RunResults.IgnoredCount,RunResults.IgnoredCount,sDate,sTime]));
+  sExeName := ExtractFileName(sExeName);
+
+  if RunResults.AllPassed then
+    sResult := 'Success'
+  else
+    sResult := 'Failure';
+
+  Indent;
+  //TODO: Populate these properly.
+//  WriteXMLLine('<environment nunit-version="DUnitX" clr-version="2.0.0.0" os-version="6.1.0.0" platform="Windows" cwd="" machine-name="" user="" user-domain=""  />');
+  WriteXMLLine('<culture-info current-culture="en" current-uiculture="en" />');
+  WriteXMLLine(Format('<test-suite type="Assembly" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0">',[sExeName,sResult,BoolToStr(RunResults.AllPassed,true),sTime]));
+  Indent;
+  WriteXMLLine('<results>');
+
+  Indent;
+  for fixtureRes in RunResults.FixtureResults do
+    WriteFixtureResult(fixtureRes);
+  Outdent;
+  WriteXMLLine('</results>');
+  Outdent;
+  WriteXMLLine('</test-suite>');
+  Outdent;
+  WriteXMLLine('</test-results>');
+
+end;
+
+procedure TDUnitXXMLJUnitLogger.Outdent;
+begin
+  Dec(FIndent,2);
+end;
+
+procedure TDUnitXXMLJUnitLogger.WriteFixtureResult(const fixtureResult: IFixtureResult);
+var
+  sResult : string;
+  sTime   : string;
+  sLineEnd : string;
+  child : IFixtureResult;
+  testResult : ITestResult;
+  sExecuted : string;
+  sName: string;
+  sSuccess: string;
+begin
+  Indent;
+  try
+    if not fixtureResult.HasFailures then
+      sResult := 'Success'
+    else
+      sResult := 'Failure';
+    sTime := Format('%.3f',[fixtureResult.Duration.TotalSeconds]);
+
+    sName := EscapeForXML(fixtureResult.Fixture.Name);
+    sResult := EscapeForXML(sResult);
+    sSuccess := EscapeForXML(BoolToStr(not fixtureResult.HasFailures,true));
+    sTime := EscapeForXML(sTime);
+
+    //its a real fixture if the class is not TObject.
+    if (not fixtureResult.Fixture.TestClass.ClassNameIs('TObject'))  then
+    begin
+      //if there were no tests then just ignore this fixture.
+      if fixtureResult.ResultCount = 0 then
+        exit;
+      sExecuted := BoolToStr(fixtureResult.ResultCount > 0,true);
+      sExecuted := EscapeForXML(sExecuted);
+
+      WriteXMLLine(Format('<test-suite type="Fixture" name="%s" executed="%s" result="%s" success="%s" time="%s" >',[sName, sExecuted, sResult, sSuccess, sTime]));
+        WriteCategoryNodes(fixtureResult.Fixture.Categories);
+          Indent;
+          WriteXMLLine('<results>');
+          for testResult in fixtureResult.TestResults do
+          begin
+            WriteTestResult(testResult);
+          end;
+
+          for child in fixtureResult.Children do
+          begin
+            WriteFixtureResult(child);
+          end;
+          WriteXMLLine('</results>');
+        Outdent;
+        WriteXMLLine('</test-suite>');
+    end
+    else
+    begin
+      if fixtureResult.ChildCount = 0 then
+        sLineEnd := '/';
+      //It's a Namespace.
+
+      WriteXMLLine(Format('<test-suite type="Namespace" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0" %s>',[sName, sResult, sSuccess, sTime, sLineEnd]));
+
+      if fixtureResult.ChildCount > 0 then
+      begin
+        Indent;
+        WriteXMLLine('<results>');
+        Indent;
+        for child in fixtureResult.Children do
+        begin
+            WriteFixtureResult(child);
+        end;
+        Outdent;
+        WriteXMLLine('</results>');
+        Outdent;
+        WriteXMLLine('</test-suite>');
+      end;
+    end;
+  finally
+    Outdent;
+  end;
+end;
+
+function ResultTypeToString(const value : TTestResultType) : string;
+begin
+  case value of
+    TTestResultType.Pass: result := 'Success';
+    TTestResultType.Failure : result := 'Failure';
+    TTestResultType.Error   : result := 'Error';
+    TTestResultType.Ignored : result := 'Ignored';
+    TTestResultType.MemoryLeak : result := 'Failure'; //JUnit xml doesn't understand memory leak
+  else
+    result := GetEnumName(TypeInfo(TTestResultType),Ord(value));
+  end;
+end;
+
+procedure TDUnitXXMLJUnitLogger.WriteTestResult(const testResult: ITestResult);
+var
+  sLineEnd : string;
+  sResult  : string;
+  sTime : string;
+  sExecuted : string;
+  sSuccess : string;
+  sName : string;
+begin
+  Indent;
+  try
+    sTime := Format('%.3f',[testResult.Duration.TotalSeconds]);
+    sResult := ResultTypeToString(testResult.ResultType);
+    if (testResult.ResultType = TTestResultType.Pass) and (testResult.Test.Categories.Count = 0)  then
+      sLineEnd := '/';
+    sExecuted := BoolToStr(testResult.ResultType <> TTestResultType.Ignored,true);
+
+    if testResult.ResultType <> TTestResultType.Ignored then
+      sSuccess := Format('success="%s"',[EscapeForXML(BoolToStr(testResult.ResultType = TTestResultType.Pass, true))])
+    else
+      sSuccess := '';
+
+    sName := EscapeForXML(testResult.Test.Name);
+    sExecuted := EscapeForXML(sExecuted);
+    sResult := EscapeForXML(sResult);
+    sTime := EscapeForXML(sTime);
+
+    WriteXMLLine(Format('<test-case name="%s" executed="%s" result="%s" %s time="%s" asserts="0" %s>', [sName, sExecuted, sResult, sSuccess, sTime, sLineEnd]));
+    WriteCategoryNodes(testResult.Test.Categories);
+    case testResult.ResultType of
+      TTestResultType.MemoryLeak,
+      TTestResultType.Failure,
+      TTestResultType.Error:
+      begin
+        Indent;
+        WriteXMLLine('<failure>');
+        Indent;
+          WriteXMLLine('<message>');
+          Indent;
+            WriteXMLLine(Format('<![CDATA[ %s ]]>',[EscapeForXML(testResult.Message, False, True)]));
+          Outdent;
+          WriteXMLLine('</message>');
+        Outdent;
+        Indent;
+          WriteXMLLine('<stack-trace>');
+          Indent;
+            WriteXMLLine(Format('<![CDATA[ %s ]]>',[EscapeForXML(testResult.StackTrace, False, True)]));
+          Outdent;
+          WriteXMLLine('</stack-trace>');
+        Outdent;
+        WriteXMLLine('</failure>');
+      end;
+      TTestResultType.Ignored:
+      begin
+        Indent;
+        WriteXMLLine('<reason>');
+        Indent;
+          WriteXMLLine('<message>');
+          Indent;
+            WriteXMLLine(Format('<![CDATA[ %s ]]>',[EscapeForXML(testResult.Message, False, True)]));
+          Outdent;
+          WriteXMLLine('</message>');
+        Outdent;
+        WriteXMLLine('</reason>');
+      end;
+      TTestResultType.Pass :
+      begin
+        if testResult.Test.Categories.Count = 0 then
+        begin
+          exit;
+        end;
+        Indent;
+      end;
+    end;
+    Outdent;
+    WriteXMLLine('</test-case>');
+
+  finally
+    Outdent;
+  end;
+end;
+
+procedure TDUnitXXMLJUnitLogger.WriteCategoryNodes(const ACategoryList: TList<string>);
+var
+  sCategory: string;
+begin
+  if ACategoryList.Count > 0 then
+  begin
+    Indent;
+    WriteXMLLine('<categories>');
+    Indent;
+    for sCategory in ACategoryList do
+      WriteXMLLine(Format('<category name="%s" />', [sCategory]));
+    Outdent;
+    WriteXMLLine('</categories>');
+    Outdent;
+  end;
+end;
+
+
+procedure TDUnitXXMLJUnitLogger.WriteXMLLine(const value: string);
+var
+  bytes : TBytes;
+  s : string;
+begin
+  s := StringOfChar(' ',FIndent) + value + #13#10;
+  bytes := TEncoding.UTF8.GetBytes(s);
+  FOutputStream.Write(bytes[0],Length(bytes));
+end;
+
+{ TDUnitXXMLJUnitFileLogger }
+
+constructor TDUnitXXMLJUnitFileLogger.Create(const AFilename: string);
+var
+  sXmlFilename  : string;
+  fileStream    : TFileStream;
+  lXmlDirectory: string;
+const
+  DEFAULT_JUNIT_FILE_NAME = 'dunitx-results.xml';
+begin
+  sXmlFilename := AFilename;
+
+  if sXmlFilename = '' then
+    sXmlFilename := ExtractFilePath(ParamStr(0)) + DEFAULT_JUNIT_FILE_NAME;
+
+  lXmlDirectory := ExtractFilePath(sXmlFilename);
+  ForceDirectories(lXmlDirectory);
+
+  fileStream := TFileStream.Create(sXmlFilename, fmCreate);
+
+  //base class will destroy the stream;
+  inherited Create(fileStream,true);
+end;
+
+end.

--- a/Source/DUnitX.Loggers.XML.JUnit.pas
+++ b/Source/DUnitX.Loggers.XML.JUnit.pas
@@ -270,36 +270,20 @@ begin
   sExeName := ParamStr(0);
   FIndent := 0;
   sTime := Format('%.3f',[RunResults.Duration.TotalSeconds]);
-  sDate := FormatDateTime('yyyy-MM-dd',RunResults.StartTime);
+  sDate := FormatDateTime('yyyy-MM-dd"T"hh:nn:ss',RunResults.StartTime);
 
-  WriteXMLLine('<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>');
-  WriteXMLLine(Format('<test-results name="%s" total="%d" errors="%d" failures="%d" ignored="%d" inconclusive="0" not-run="%d" skipped="0" invalid="0" date="%s" time="%s">',
-                      [sExeName,totalTests,RunResults.ErrorCount,RunResults.FailureCount,RunResults.IgnoredCount,RunResults.IgnoredCount,sDate,sTime]));
-  sExeName := ExtractFileName(sExeName);
-
-  if RunResults.AllPassed then
-    sResult := 'Success'
-  else
-    sResult := 'Failure';
-
+  WriteXMLLine('<?xml version="1.0" encoding="UTF-8"?>');
+  WriteXMLLine('<testsuites>');
   Indent;
-  //TODO: Populate these properly.
-//  WriteXMLLine('<environment nunit-version="DUnitX" clr-version="2.0.0.0" os-version="6.1.0.0" platform="Windows" cwd="" machine-name="" user="" user-domain=""  />');
-  WriteXMLLine('<culture-info current-culture="en" current-uiculture="en" />');
-  WriteXMLLine(Format('<test-suite type="Assembly" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0">',[sExeName,sResult,BoolToStr(RunResults.AllPassed,true),sTime]));
-  Indent;
-  WriteXMLLine('<results>');
 
-  Indent;
+  // Global overview
+  WriteXMLLine(Format('<testsuite name="%s" errors="%d" tests="%d" failures="%d" time="%s" timestamp="%s" />',[sExeName,RunResults.ErrorCount, RunResults.TestCount, RunResults.FailureCount, sTime, sDate]));
+
   for fixtureRes in RunResults.FixtureResults do
     WriteFixtureResult(fixtureRes);
-  Outdent;
-  WriteXMLLine('</results>');
-  Outdent;
-  WriteXMLLine('</test-suite>');
-  Outdent;
-  WriteXMLLine('</test-results>');
 
+  Outdent;
+  WriteXMLLine('</testsuites>');
 end;
 
 procedure TDUnitXXMLJUnitLogger.Outdent;
@@ -318,7 +302,7 @@ var
   sName: string;
   sSuccess: string;
 begin
-  Indent;
+  //Indent;
   try
     if not fixtureResult.HasFailures then
       sResult := 'Success'
@@ -326,7 +310,7 @@ begin
       sResult := 'Failure';
     sTime := Format('%.3f',[fixtureResult.Duration.TotalSeconds]);
 
-    sName := EscapeForXML(fixtureResult.Fixture.Name);
+    sName := EscapeForXML(fixtureResult.Fixture.FullName);
     sResult := EscapeForXML(sResult);
     sSuccess := EscapeForXML(BoolToStr(not fixtureResult.HasFailures,true));
     sTime := EscapeForXML(sTime);
@@ -340,22 +324,19 @@ begin
       sExecuted := BoolToStr(fixtureResult.ResultCount > 0,true);
       sExecuted := EscapeForXML(sExecuted);
 
-      WriteXMLLine(Format('<test-suite type="Fixture" name="%s" executed="%s" result="%s" success="%s" time="%s" >',[sName, sExecuted, sResult, sSuccess, sTime]));
-        WriteCategoryNodes(fixtureResult.Fixture.Categories);
-          Indent;
-          WriteXMLLine('<results>');
-          for testResult in fixtureResult.TestResults do
-          begin
-            WriteTestResult(testResult);
-          end;
+      WriteXMLLine(Format('<testsuite type="Fixture" name="%s" executed="%s" result="%s" success="%s" time="%s" >',[sName, sExecuted, sResult, sSuccess, sTime]));
 
-          for child in fixtureResult.Children do
-          begin
-            WriteFixtureResult(child);
-          end;
-          WriteXMLLine('</results>');
-        Outdent;
-        WriteXMLLine('</test-suite>');
+        //WriteCategoryNodes(fixtureResult.Fixture.Categories);
+      for testResult in fixtureResult.TestResults do
+      begin
+        WriteTestResult(testResult);
+      end;
+      WriteXMLLine('</testsuite>');
+
+      for child in fixtureResult.Children do
+      begin
+        WriteFixtureResult(child);
+      end;
     end
     else
     begin
@@ -363,25 +344,25 @@ begin
         sLineEnd := '/';
       //It's a Namespace.
 
-      WriteXMLLine(Format('<test-suite type="Namespace" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0" %s>',[sName, sResult, sSuccess, sTime, sLineEnd]));
+      //WriteXMLLine(Format('<test-suite type="Namespace" name="%s" executed="true" result="%s" success="%s" time="%s" asserts="0" %s>',[sName, sResult, sSuccess, sTime, sLineEnd]));
 
       if fixtureResult.ChildCount > 0 then
       begin
-        Indent;
-        WriteXMLLine('<results>');
-        Indent;
+//        Indent;
+//        WriteXMLLine('<results>');
+//        Indent;
         for child in fixtureResult.Children do
         begin
             WriteFixtureResult(child);
         end;
-        Outdent;
-        WriteXMLLine('</results>');
-        Outdent;
-        WriteXMLLine('</test-suite>');
+//        Outdent;
+//        WriteXMLLine('</results>');
+//        Outdent;
+//        WriteXMLLine('</test-suite>');
       end;
     end;
   finally
-    Outdent;
+    //Outdent;
   end;
 end;
 
@@ -425,8 +406,8 @@ begin
     sResult := EscapeForXML(sResult);
     sTime := EscapeForXML(sTime);
 
-    WriteXMLLine(Format('<test-case name="%s" executed="%s" result="%s" %s time="%s" asserts="0" %s>', [sName, sExecuted, sResult, sSuccess, sTime, sLineEnd]));
-    WriteCategoryNodes(testResult.Test.Categories);
+    WriteXMLLine(Format('<testcase name="%s" executed="%s" result="%s" %s time="%s" asserts="0" %s>', [sName, sExecuted, sResult, sSuccess, sTime, sLineEnd]));
+    //WriteCategoryNodes(testResult.Test.Categories);
     case testResult.ResultType of
       TTestResultType.MemoryLeak,
       TTestResultType.Failure,
@@ -473,7 +454,7 @@ begin
       end;
     end;
     Outdent;
-    WriteXMLLine('</test-case>');
+    WriteXMLLine('</testcase>');
 
   finally
     Outdent;

--- a/Tests/DUnitX.Tests.Loggers.XML.JUnit.pas
+++ b/Tests/DUnitX.Tests.Loggers.XML.JUnit.pas
@@ -1,0 +1,282 @@
+{***************************************************************************}
+{                                                                           }
+{           DUnitX                                                          }
+{                                                                           }
+{           Copyright (C) 2012 Vincent Parrett                              }
+{                                                                           }
+{           vincent@finalbuilder.com                                        }
+{           http://www.finalbuilder.com                                     }
+{                                                                           }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Licensed under the Apache License, Version 2.0 (the "License");          }
+{  you may not use this file except in compliance with the License.         }
+{  You may obtain a copy of the License at                                  }
+{                                                                           }
+{      http://www.apache.org/licenses/LICENSE-2.0                           }
+{                                                                           }
+{  Unless required by applicable law or agreed to in writing, software      }
+{  distributed under the License is distributed on an "AS IS" BASIS,        }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. }
+{  See the License for the specific language governing permissions and      }
+{  limitations under the License.                                           }
+{                                                                           }
+{***************************************************************************}
+
+unit DUnitX.Tests.Loggers.XML.JUnit;
+
+
+interface
+
+{$I DUnitX.inc}
+
+uses
+  {$IFDEF USE_NS}
+  System.Classes,
+  {$ELSE}
+  Classes,
+  {$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.Loggers.XML.JUnit;
+
+
+type
+  {$M+}
+  [TestFixture]
+  TDUnitX_LoggerXMLJUnitTests = class
+  public
+    [Test(false)]
+    procedure OnTestingStarts_Fills_The_Start_Of_The_Stream_With_Header_Info;
+  //  [Test(false)]
+//    procedure OnTestingEnds_Fills_The_End_Of_The_Stream_With_Testing_Result_Info;
+{$IFNDEF DELPHI_XE_DOWN}
+    [Test(false)]
+    procedure OnTestWarning_Adds_Warnings_To_Be_Written_Out_On_Next_Error;
+    procedure OnTestWarning_Adds_Warnings_To_Be_Written_Out_On_Next_Success;
+{$ENDIF}
+  end;
+
+implementation
+
+uses
+  {$IFDEF USE_NS}
+  System.Rtti,
+  System.SysUtils,
+  System.TimeSpan,
+  System.DateUtils,
+  {$ELSE}
+  Rtti,
+  SysUtils,
+  TimeSpan,
+  DateUtils,
+  {$ENDIF}
+{$IFNDEF DELPHI_XE_DOWN}
+  Delphi.Mocks,
+{$ENDIF}
+  DUnitX.Generics,
+  DUnitX.RunResults;
+
+const
+  CRLF = #13#10;
+
+{ TDUnitX_LoggerXMLNUnit }
+
+{
+procedure TDUnitX_LoggerXMLJUnitTests.OnTestingEnds_Fills_The_End_Of_The_Stream_With_Testing_Result_Info;
+var
+  logger : ITestLogger;
+  mockStream : TStringStream;
+  mockResults : TMock<ITestResults>;
+
+  sExpectedEnding : string;
+
+  TempStartTime: TDateTime;
+  TempFinishTime: TDateTime;
+  StartTimeStr: string;
+  FinishTimeStr: string;
+
+begin
+  mockStream := TStringStream.Create('', TEncoding.UTF8);
+
+  mockResults := TMock<ITestResults>.Create;
+  mockResults.Setup.WillReturn(6).When.Count;
+  mockResults.Setup.WillReturn(3).When.FailureCount;
+  mockResults.Setup.WillReturn(1).When.ErrorCount;
+  mockResults.Setup.WillReturn(50).When.SuccessRate;
+    mockResults.Setup.WillReturn(3).When.IgnoredCount;
+
+  TempStartTime := EncodeDateTime(2000, 2, 1, 11, 32, 50, 0);
+  TempFinishTime := EncodeDateTime(2000, 2, 28, 12, 34, 56, 0);
+  StartTimeStr := DateTimeToStr(TempStartTime);
+  FinishTimeStr := DateTimeToSTr(TempFinishTime);
+
+
+  mockResults.Setup.WillReturn(TempStartTime).When.StartTime;
+  mockResults.Setup.WillReturn(TempFinishTime).When.FinishTime;
+  mockResults.Setup.WillReturn(TValue.From<TTimeSpan>(TTimeSpan.FromMilliseconds(80129120))).When.TestDuration;
+
+  logger := TDUnitXXMLNUnitLogger.Create(mockStream);
+  logger.OnTestingEnds(mockResults);
+
+  sExpectedEnding :=  '<statistics>' + CRLF +
+                  Format('<stat name="tests" value="%d" />', [6]) + CRLF +
+                  Format('<stat name="failures" value="%d" />', [3]) + CRLF +
+                  Format('<stat name="errors" value="%d" />', [1]) + CRLF +
+                  Format('<stat name="ignored" value="%d" />', [3]) + CRLF +
+                  Format('<stat name="success-rate" value="%d%%" />', [50]) + CRLF +
+                  Format('<stat name="started-at" value="%s" />', [StartTimeStr]) + CRLF +
+                  Format('<stat name="finished-at" value="%s" />', [FinishTimeStr]) + CRLF +
+                  Format('<stat name="runtime" value="%1.3f"/>', [80129.120]) + CRLF +
+                  '</statistics>' + CRLF +
+              '</test-results>';
+
+  Assert.AreEqual<string>(mockStream.DataString, sExpectedEnding);
+end;
+ }
+procedure TDUnitX_LoggerXMLJUnitTests.OnTestingStarts_Fills_The_Start_Of_The_Stream_With_Header_Info;
+var
+  sUnicodePreamble: string;
+  logger : ITestLogger;
+  mockStream : TStringStream;
+  sOnTestingStartsText : string;
+  sHeader: string;
+  sResults: string;
+  sAppName: string;
+  sExpectedResults : string;
+  sExpectedAppName : string;
+  iPrevLastChar: Integer;
+const
+  EXPECTED_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>';
+  EXPECTED_RESULTS_FORMAT_STR = '<test-results total="%d" notrun="%d" date="%s" time="%s" >';
+  EXPECTED_APP_NAME_FORMAT_STR = '<application name="%s" />';
+begin
+  //TODO: Break this unit tests into three separate specific tests for each of the header sections.
+  mockStream := TStringStream.Create('', TEncoding.UTF8);
+  logger := TDUnitXXMLJUnitLogger.Create(mockStream);
+  logger.OnTestingStarts(0, 40, 30);
+
+  sOnTestingStartsText := mockStream.DataString;
+
+  //Expected results
+  //TODO: Fix this dangerous tests around "NOW"
+  sExpectedResults := Format(EXPECTED_RESULTS_FORMAT_STR,
+                         [40, 40 - 30, DateToStr(Now), TimeToStr(Now)]);
+
+  sExpectedAppName := Format(EXPECTED_APP_NAME_FORMAT_STR,
+                         [ExtractFileName(ParamStr(0))]);
+
+  iPrevLastChar := 0;
+  //Check the preamble
+  sUnicodePreamble := TEncoding.UTF8.GetString(TEncoding.UTF8.GetPreamble);
+
+  Assert.AreEqual(Copy(sOnTestingStartsText, iPrevLastChar, Length(sUnicodePreamble)), sUnicodePreamble);
+  iPrevLastChar := iPrevLastChar + Length(sUnicodePreamble);
+
+  //Check the header
+  sHeader := Copy(sOnTestingStartsText, Succ(iPrevLastChar), Length(EXPECTED_HEADER));
+  iPrevLastChar := iPrevLastChar + Length(EXPECTED_HEADER);
+
+  sResults := Copy(sOnTestingStartsText, Succ(iPrevLastChar), Length(sExpectedResults));
+  iPrevLastChar := iPrevLastChar + Length(sExpectedResults);
+
+  sAppName := Copy(sOnTestingStartsText, Succ(iPrevLastChar), Length(sExpectedAppName));
+
+  Assert.AreEqual(sHeader, EXPECTED_HEADER);
+
+  Assert.AreEqual(sResults, sExpectedResults);
+
+  Assert.AreEqual(sAppName, sExpectedAppName);
+end;
+
+{$IFNDEF DELPHI_XE_DOWN}
+procedure TDUnitX_LoggerXMLJUnitTests.OnTestWarning_Adds_Warnings_To_Be_Written_Out_On_Next_Error;
+var
+  logger : ITestLogger;
+  mockStream : TStringStream;
+  mockWarning : TMock<ITestResult>;
+  mockFixture : TMock<ITestFixtureInfo>;
+  mockTest : TMock<ITestInfo>;
+  mockError: TMock<ITestError>;
+
+  sExceptedWarning : string;
+  iPositionOfWarning: Integer;
+begin
+  //Mocks
+  mockStream := TStringStream.Create('', TEncoding.UTF8);
+  mockWarning := TMock<ITestResult>.Create;
+  mockFixture := TMock<ITestFixtureInfo>.Create;
+  mockTest := TMock<ITestInfo>.Create;
+  mockError := TMock<ITestError>.Create;
+
+  //System under test
+  logger := TDUnitXXMLJUnitLogger.Create(mockStream);
+
+  //Setup
+  //TODO: Would be nice in Delphi.Mocks to have a auto mock of interface and object properties.
+  mockFixture.Setup.WillReturn('WarningFixture').When.Name;
+  mockTest.Setup.WillReturn('WarningTest').When.Name;
+  mockTest.Setup.WillReturn('WarningTest').When.FullName;
+  mockTest.Setup.WillReturn(True).When.Active;
+  mockWarning.Setup.WillReturn('!!WarningMessage!!').When.Message;
+  mockWarning.Setup.WillReturn(mockTest.InstanceAsValue).When.Test;
+  mockError.Setup.WillReturn(mockTest.InstanceAsValue).When.Test;
+  mockError.Setup.WillReturn(TValue.From<TTimeSpan>(TTimeSpan.FromMilliseconds(0))).When.Duration;
+  mockError.Setup.WillReturn(Exception).When.ExceptionClass;
+  mockError.Setup.WillReturn('').When.ExceptionLocationInfo;
+  mockError.Setup.WillReturn('').When.ExceptionMessage;
+
+  sExceptedWarning := Format('WARNING: %s: %s', [mockTest.Instance.Name, mockWarning.Instance.Message]);
+
+  //Call
+  logger.OnTestError(0, mockError);
+
+  //Verify
+  iPositionOfWarning := Pos(sExceptedWarning, mockStream.DataString);
+  Assert.IsTrue(iPositionOfWarning > 0);
+  Assert.AreEqual(Copy(mockStream.DataString, iPositionOfWarning, Length(sExceptedWarning)), sExceptedWarning);
+end;
+
+procedure TDUnitX_LoggerXMLJUnitTests.OnTestWarning_Adds_Warnings_To_Be_Written_Out_On_Next_Success;
+var
+  logger : ITestLogger;
+  mockStream : TStringStream;
+  mockWarning : TMock<ITestResult>;
+  mockTest : TMock<ITestInfo>;
+  mockSuccess: TMock<ITestError>;
+
+  sExceptedWarning : string;
+  iPositionOfWarning: Integer;
+begin
+  //Mocks
+  mockStream := TStringStream.Create('', TEncoding.UTF8);
+  mockWarning := TMock<ITestResult>.Create;
+  mockTest := TMock<ITestInfo>.Create;
+  mockSuccess := TMock<ITestError>.Create;
+
+  //System under test
+  logger := TDUnitXXMLJUnitLogger.Create(mockStream);
+
+  //Setup
+  mockTest.Setup.WillReturn('SuccessfulTest').When.Name;
+  mockWarning.Setup.WillReturn('Warning').When.Message;
+
+  //TODO: Would be nice in Delphi.Mocks to have a auto mock of interface and object properties.
+  mockWarning.Setup.WillReturn(mockTest.InstanceAsValue).When.Test;
+
+  sExceptedWarning := Format('WARNING: %s: %s', [mockTest.Instance.Name, mockWarning.Instance.Message]);
+
+  //Call
+  logger.OnTestSuccess(0, mockSuccess);
+
+  //Verify
+  iPositionOfWarning := Pos(sExceptedWarning, mockStream.DataString);
+  Assert.IsTrue(iPositionOfWarning > 0);
+  Assert.AreEqual(Copy(mockStream.DataString, iPositionOfWarning, Length(sExceptedWarning)), sExceptedWarning);
+end;
+{$ENDIF}
+
+initialization
+  TDUnitX.RegisterTestFixture(TDUnitX_LoggerXMLJUnitTests);
+end.
+

--- a/Tests/DUnitXTestProject.dpr
+++ b/Tests/DUnitXTestProject.dpr
@@ -40,7 +40,8 @@ uses
   DUnitX.Tests.ConsoleWriter.Base in 'DUnitX.Tests.ConsoleWriter.Base.pas',
   DUnitX.Tests.TestDataProvider in 'DUnitX.Tests.TestDataProvider.pas',
   DUnitX.Tests.IgnoreFixture in 'DUnitX.Tests.IgnoreFixture.pas',
-  DUnitX.Tests.Utils in 'DUnitX.Tests.Utils.pas';
+  DUnitX.Tests.Utils in 'DUnitX.Tests.Utils.pas',
+  DUnitX.Tests.Loggers.XML.JUnit in 'DUnitX.Tests.Loggers.XML.JUnit.pas';
 
 var
   runner : ITestRunner;

--- a/Tests/DUnitXTest_D10Tokyo.dproj
+++ b/Tests/DUnitXTest_D10Tokyo.dproj
@@ -111,15 +111,16 @@
         <DCCReference Include="DUnitX.Tests.TestDataProvider.pas"/>
         <DCCReference Include="DUnitX.Tests.IgnoreFixture.pas"/>
         <DCCReference Include="DUnitX.Tests.Utils.pas"/>
+        <DCCReference Include="DUnitX.Tests.Loggers.XML.JUnit.pas"/>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
         <BuildConfiguration Include="Release">
             <Key>Cfg_1</Key>
-            <CfgParent>Base</CfgParent>
-        </BuildConfiguration>
-        <BuildConfiguration Include="Debug">
-            <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>

--- a/Tests/DUnitXTest_XE2.dproj
+++ b/Tests/DUnitXTest_XE2.dproj
@@ -105,15 +105,16 @@
         <DCCReference Include="DUnitX.Tests.TestDataProvider.pas"/>
         <DCCReference Include="DUnitX.Tests.IgnoreFixture.pas"/>
         <DCCReference Include="DUnitX.Tests.Utils.pas"/>
+        <DCCReference Include="DUnitX.Tests.Loggers.XML.JUnit.pas"/>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
         <BuildConfiguration Include="Release">
             <Key>Cfg_1</Key>
-            <CfgParent>Base</CfgParent>
-        </BuildConfiguration>
-        <BuildConfiguration Include="Debug">
-            <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>


### PR DESCRIPTION
Responding to https://github.com/VSoftTechnologies/DUnitX/issues/258 I have written an XML logger that follows the JUnit format, lending from https://help.catchsoftware.com/display/ET/JUnit+Format

I realized that for _NUnit_, all output format checking tests are disabled, and that if these are enabled, the mockStream.DataString is empty so the assertions fail. I assume that you tend to manually verify the _NUnit_ XML output, e.g. by trying to get it parsed.

I've done the following external verification of the JUnit XML logger:
- Changing the logger used in DUnitXTestProject and verifying that the output looks correct
- Use the JUnit logger in a (closed source) repository where we're using DUnitX, and verify that Gitlab CI properly parses the output. Introduced some errors/failures on purpose to check that those also are reported properly