### PR TITLE
Fixed compiler warning for Berlin 10.1

### DIFF
--- a/Source/DUnitX.Timeout.pas
+++ b/Source/DUnitX.Timeout.pas
@@ -153,8 +153,7 @@ begin
   stopwatch.Reset;
   stopwatch.Start;
 
-  // TODO: Not sure if 10.1 is absolutely correct, but 10.2 atleast this gives hint
-  {$IFDEF DELPHI_XE101_DOWN} // <- H2077 Value assigned to 'elapsedTime' never used 10.2 Tokyo and up
+  {$IFDEF DELPHI_XE100_DOWN} // <- H2077 Value assigned to 'elapsedTime' never used 10.1 Berlin and up
   elapsedTime := 0;
   {$ENDIF}
 


### PR DESCRIPTION
Berlin 10.1 also issues the same warning, so I made this small change since some organizations use acceptance policies of 0 warnings in the CI process.