### PR TITLE
Up version to D2010

### DIFF
--- a/Source/DUnitX.Windows.Console.pas
+++ b/Source/DUnitX.Windows.Console.pas
@@ -217,7 +217,7 @@ end;
 {$IFDEF MSWINDOWS}
 initialization
     //Refer to IoC.pas for why the double generic class function isn't being used.
-{$IFDEF DELPHI_XE_UP}
+{$IFDEF DELPHI_2010_UP}
     TDUnitXIoC.DefaultContainer.RegisterType<IDUnitXConsoleWriter,TDUnitXWindowsConsoleWriter>;
 {$ELSE}
     TDUnitXIoC.DefaultContainer.RegisterType<IDUnitXConsoleWriter>(


### PR DESCRIPTION
I am running this on D2010 and the shorter version runs fine on it.
The {ELSE} actually creates a memory leak which I have not been able to track down:
The block is currently used for an object of class: DUnitX.Windows.Console$ActRec