### PR TITLE
Fix #287 - Summary of JUnit test results should be at the "testsuites" node

### DIFF
--- a/Source/DUnitX.Loggers.XML.JUnit.pas
+++ b/Source/DUnitX.Loggers.XML.JUnit.pas
@@ -161,7 +161,6 @@ var
   fixtureRes  : IFixtureResult;
   sExeName    : string;
   sTime       : string;
-  sDate       : string;
   //totalTests  : integer;
 begin
 
@@ -180,14 +179,15 @@ begin
   sExeName := ParamStr(0);
   FIndent := 0;
   sTime := Format('%.3f',[RunResults.Duration.TotalSeconds]);
-  sDate := FormatDateTime('yyyy-MM-dd"T"hh:nn:ss',RunResults.StartTime);
 
   WriteXMLLine('<?xml version="1.0" encoding="UTF-8"?>');
-  WriteXMLLine('<testsuites>');
-  Indent;
 
   // Global overview
-  WriteXMLLine(Format('<testsuite name="%s" tests="%d" skipped="%d" errors="%d" failures="%d" time="%s" timestamp="%s" />',[sExeName,RunResults.TestCount, RunResults.IgnoredCount, RunResults.ErrorCount, RunResults.FailureCount, sTime, sDate]));
+  // There is only a "disabled" attribute on the top level, but "disabled" and "skipped" on fixture level. Return ignored tests as "disabled"
+  WriteXMLLine(Format('<testsuites name="%s" tests="%d" disabled="%d" errors="%d" failures="%d" time="%s"/>',
+    [sExeName,RunResults.TestCount, RunResults.IgnoredCount, RunResults.ErrorCount, RunResults.FailureCount, sTime]));
+
+  Indent;
 
   for fixtureRes in RunResults.FixtureResults do
     WriteFixtureResult(fixtureRes);
@@ -226,7 +226,9 @@ begin
       sExecuted := BoolToStr(fixtureResult.ResultCount > 0,true);
       sExecuted := EscapeForXML(sExecuted);
 
-      WriteXMLLine(Format('<testsuite name="%s" tests="%d" skipped="%d" errors="%d" failures="%d" time="%s" timestamp="%s">',[sName, fixtureResult.TestResults.Count, fixtureResult.IgnoredCount, fixtureResult.ErrorCount, fixtureResult.FailureCount, sTime, sDate]));
+      // There is only a "disabled" attribute on the top level, but "disabled" and "skipped" on fixture level. Return ignored tests as "disabled"
+      WriteXMLLine(Format('<testsuite name="%s" tests="%d" disabled="%d" errors="%d" failures="%d" time="%s" timestamp="%s">',
+        [sName, fixtureResult.TestResults.Count, fixtureResult.IgnoredCount, fixtureResult.ErrorCount, fixtureResult.FailureCount, sTime, sDate]));
       //WriteCategoryNodes(fixtureResult.Fixture.Categories);
 
       for testResult in fixtureResult.TestResults do


### PR DESCRIPTION
- Summary of test results reported at the "testsuites" node
- report ignored tests as "disabled" on testsuite and fixture level for consistency