### PR TITLE
Updates for Delphi 2010 Tests\Examples

### DIFF
--- a/Examples/DUnitX.Examples.General.pas
+++ b/Examples/DUnitX.Examples.General.pas
@@ -71,6 +71,9 @@ type
     procedure TestError;
 
     [Test]
+    {$IFDEF DELPHI_2010}
+    [Ignore('MaxTime does not work in D2010')]
+    {$ENDIF}
     [MaxTime(2000)]
     procedure TooLong;
 

--- a/Examples/DUnitXExamples_2010.dpr
+++ b/Examples/DUnitXExamples_2010.dpr
@@ -62,6 +62,7 @@ begin
     //Create the runner
     runner := TDUnitX.CreateRunner;
     runner.UseRTTI := True;
+    TDUnitX.Options.ExitBehavior := TDUnitXExitBehavior.Pause;
 
     //tell the runner how we will log things
 

--- a/Examples/DUnitXExamples_2010.dpr
+++ b/Examples/DUnitXExamples_2010.dpr
@@ -47,7 +47,8 @@ uses
   DUnitX.Utils in '..\Source\DUnitX.Utils.pas',
   DUnitX.Attributes in '..\Source\DUnitX.Attributes.pas',
   DUnitX.Types in '..\Source\DUnitX.Types.pas',
-  DUnitX.Timeout in '..\Source\DUnitX.Timeout.pas';
+  DUnitX.Timeout in '..\Source\DUnitX.Timeout.pas',
+  DUnitX.Exceptions in '..\Source\DUnitX.Exceptions.pas';
 
 var
   runner : ITestRunner;

--- a/Examples/DUnitXExamples_2010.dproj
+++ b/Examples/DUnitXExamples_2010.dproj
@@ -92,6 +92,7 @@
 			<DCCReference Include="..\Source\DUnitX.Attributes.pas"/>
 			<DCCReference Include="..\Source\DUnitX.Types.pas"/>
 			<DCCReference Include="..\Source\DUnitX.Timeout.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Exceptions.pas"/>
 			<BuildConfiguration Include="Base">
 				<Key>Base</Key>
 			</BuildConfiguration>

--- a/Source/DUnitX.Loggers.Text.pas
+++ b/Source/DUnitX.Loggers.Text.pas
@@ -87,6 +87,9 @@ type
 implementation
 
 uses
+  {$IFDEF DELPHI_2010}
+  DUnitX.Exceptions, //ENotImplemented is not in SysUtils in D2010
+  {$ENDIF}
   {$IFDEF USE_NS}
   System.SysUtils;
   {$ELSE}

--- a/Tests/DUnitX.SingleNameSpace.pas
+++ b/Tests/DUnitX.SingleNameSpace.pas
@@ -2,6 +2,8 @@ unit DUnitX.SingleNameSpace;
 
 interface
 
+{$I DUnitX.inc}
+
 uses
   DUnitX.TestFramework,
   DUnitX.WeakReference;
@@ -16,6 +18,10 @@ type
 implementation
 
 uses
+  {$IFDEF DELPHI_2010_DOWN}
+  //D2010 doesn't have TThread.Sleep
+  Windows,
+  {$ENDIF}
   classes;
 
 
@@ -23,7 +29,12 @@ uses
 
 procedure TSingleNamespaceTest.ATest;
 begin
-  TThread.Sleep(50);// just so we can test duration output.
+  {$IFDEF DELPHI_2010_DOWN}
+    Windows.Sleep(50);// just so we can test duration output.
+  {$ELSE}
+    TThread.Sleep(50);
+  {$ENDIF}
+
   Assert.IsTrue(true);
 end;
 

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -145,8 +145,13 @@ type
   private
     FSetupCalled : boolean;
   public
-    //testing constructor/destructor as fixture setup/teardown
+    // Testing constructor/destructor as fixture setup/teardown
+    // Delphi 2010 does support calling of constructor
+    {$IFDEF DELPHI_XE_UP}
     constructor Create;
+    {$ELSE}
+    procedure AfterConstruction; override;
+    {$ENDIF}
     destructor Destroy;override;
 
     [SetupFixture]
@@ -309,7 +314,11 @@ begin
   Assert.IsTrue(FSetupCalled);
 end;
 
+{$IFDEF DELPHI_XE_UP}
 constructor TExampleFixture3.Create;
+{$ELSE}
+procedure TExampleFixture3.AfterConstruction;
+{$ENDIF}
 begin
   FSetupCalled := True;
 end;

--- a/Tests/DUnitX.Tests.TestNameParser.pas
+++ b/Tests/DUnitX.Tests.TestNameParser.pas
@@ -9,22 +9,21 @@ type
   [TestFixture]
   TTestNameParserTests = class
   public
-
-    [TestCase('SingleName','Test.Namespace.Fixture.Method')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method,')]
-    [TestCase('SingleName','  Test.Namespace.Fixture.Method  ')]
-    [TestCase('SingleName','  Test.Namespace.Fixture.Method  ,')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method()')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method(''string,argument'')')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method(1,2,3)')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method<int,int>()')]
-    [TestCase('SingleName','Test.Namespace.Fixture.Method(")")')]
+    [TestCase('SingleName1','Test.Namespace.Fixture.Method')]
+    [TestCase('SingleName2','Test.Namespace.Fixture.Method,')]
+    [TestCase('SingleName3','  Test.Namespace.Fixture.Method  ')]
+    [TestCase('SingleName4','  Test.Namespace.Fixture.Method  ,')]
+    [TestCase('SingleName5','Test.Namespace.Fixture.Method()')]
+    [TestCase('SingleName6','Test.Namespace.Fixture.Method(''string,argument'')')]
+    [TestCase('SingleName7','Test.Namespace.Fixture.Method(1,2,3)')]
+    [TestCase('SingleName8','Test.Namespace.Fixture.Method<int,int>()')]
+    [TestCase('SingleName9','Test.Namespace.Fixture.Method(")")')]
     procedure SingleName(const name : string);
 
-    [TestCase('TwoNames','Test.Namespace.Fixture.Method1|Test.Namespace.Fixture.Method2','|')]
-    [TestCase('TwoNames','Test.Namespace.Fixture.Method1|Test.Namespace.Fixture.Method2,','|')]
-    [TestCase('TwoNames','Test.Namespace.Fixture.Method1(1,2)|Test.Namespace.Fixture.Method2(3,4)','|')]
-    [TestCase('TwoNames','Test.Namespace.Fixture.Method1("(")|Test.Namespace.Fixture.Method2("<")','|')]
+    [TestCase('TwoNames1','Test.Namespace.Fixture.Method1|Test.Namespace.Fixture.Method2','|')]
+    [TestCase('TwoNames2','Test.Namespace.Fixture.Method1|Test.Namespace.Fixture.Method2,','|')]
+    [TestCase('TwoNames3','Test.Namespace.Fixture.Method1(1,2)|Test.Namespace.Fixture.Method2(3,4)','|')]
+    [TestCase('TwoNames4','Test.Namespace.Fixture.Method1("(")|Test.Namespace.Fixture.Method2("<")','|')]
     procedure TwoNames(const name1 : string;const name2 : string);
   end;
 
@@ -58,5 +57,8 @@ begin
   Assert.AreEqual(Trim(name1), names[0]);
   Assert.AreEqual(Trim(name2), names[1]);
 end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestNameParserTests);
 
 end.

--- a/Tests/DUnitX.Tests.Utils.pas
+++ b/Tests/DUnitX.Tests.Utils.pas
@@ -32,9 +32,13 @@ type
     function GetLCIDFromLocale(const locale: string): integer;
     {$ENDIF}
   public
-    destructor Destroy; override;
-    // Using Create is not supported with D2010, but would be a good approach for XE+
+    // Delphi 2010 does support calling of constructor
+    {$IFDEF DELPHI_XE_UP}
+    constructor Create;
+    {$ELSE}
     procedure AfterConstruction; override;
+    {$ENDIF}
+    destructor Destroy; override;
     [Test]
     [TestCase('EN-US local format',                   'EN-US,06/22/2020')]
     [TestCase('EN-US iso8601 format',                 'EN-US,2020-06-22')]
@@ -83,9 +87,13 @@ implementation uses
   {$ENDIF}
   DUnitX.Utils;
 
-{ TMyExampleTests }
+{ TValueHelperTests }
 
+{$IFDEF DELPHI_XE_UP}
+constructor TValueHelperTests.Create;
+{$ELSE}
 procedure TValueHelperTests.AfterConstruction;
+{$ENDIF}
 begin
  	inherited;
   {$IFDEF DELPHI_XE_UP}

--- a/Tests/DUnitX.Tests.Utils.pas
+++ b/Tests/DUnitX.Tests.Utils.pas
@@ -17,50 +17,58 @@ type
   [Category('Utils')]
   TValueHelperTests = class
   private var
+    {$IFDEF DELPHI_XE_UP}
   	originalFormatSettings: TFormatSettings;
+    {$ELSE}
+    originalLCID: Integer;
+    {$ENDIF}
   protected var
-	expectedDate: TDate;
-	expectedTime: TTime;
+    expectedDate: TDate;
+    expectedTime: TTime;
   protected
-	procedure setFormatSettings(const locale: String);
-	procedure revertFormatSettings();
+    procedure setFormatSettings(const locale: String);
+    procedure revertFormatSettings();
+    {$IFDEF DELPHI_2010_DOWN}
+    function GetLCIDFromLocale(const locale: string): integer;
+    {$ENDIF}
   public
-	constructor Create();
-	destructor Destroy(); override;
-	[Test]
-	[TestCase('EN-US local format',                   'EN-US,06/22/2020')]
-	[TestCase('EN-US iso8601 format',                 'EN-US,2020-06-22')]
-	[TestCase('EN-GB local format',                   'EN-GB,22/06/2020')]
-	[TestCase('EN-GB iso8601 format',                 'EN-GB,2020-06-22')]
-	[TestCase('DE local format',                      'DE,22.06.2020')]
-	[TestCase('DE local format, no leading zeroes',   'DE,22.6.2020')]
-	[TestCase('DE local format, no explicit century', 'DE,22.06.20')]
-	[TestCase('DE iso8601 format',                    'DE,2020-06-22')]
-	procedure TestDateConversion(const locale: String; const text: String);
+    destructor Destroy; override;
+    // Using Create is not supported with D2010, but would be a good approach for XE+
+    procedure AfterConstruction; override;
+    [Test]
+    [TestCase('EN-US local format',                   'EN-US,06/22/2020')]
+    [TestCase('EN-US iso8601 format',                 'EN-US,2020-06-22')]
+    [TestCase('EN-GB local format',                   'EN-GB,22/06/2020')]
+    [TestCase('EN-GB iso8601 format',                 'EN-GB,2020-06-22')]
+    [TestCase('DE local format',                      'DE,22.06.2020')]
+    [TestCase('DE local format, no leading zeroes',   'DE,22.6.2020')]
+    [TestCase('DE local format, no explicit century', 'DE,22.06.20')]
+    [TestCase('DE iso8601 format',                    'DE,2020-06-22')]
+    procedure TestDateConversion(const locale: String; const text: String);
 
-	[Test]
-	[TestCase('EN-US local format, no leading zero, no seconds',   'EN-US,6:36 pm')]
-	[TestCase('EN-US local format, with seconds',                  'EN-US,06:36:00 PM')]
-	[TestCase('DE local format, no seconds',                       'DE,18:36')]
-	[TestCase('DE local format, with seconds',                     'DE,18:36:00')]
-	[TestCase('DE iso8601 format',                                 'DE,18:36:00.000')]
-	[TestCase('EN-GB local 12 h format',                           'EN-GB,06:36 pm')]
-	[TestCase('EN-GB local 24 h format',                           'EN-GB,18:36')]
-	procedure TestTimeConversion(const locale: String; const text: String);
+    [Test]
+    [TestCase('EN-US local format, no leading zero, no seconds',   'EN-US,6:36 pm')]
+    [TestCase('EN-US local format, with seconds',                  'EN-US,06:36:00 PM')]
+    [TestCase('DE local format, no seconds',                       'DE,18:36')]
+    [TestCase('DE local format, with seconds',                     'DE,18:36:00')]
+    [TestCase('DE iso8601 format',                                 'DE,18:36:00.000')]
+    [TestCase('EN-GB local 12 h format',                           'EN-GB,06:36 pm')]
+    [TestCase('EN-GB local 24 h format',                           'EN-GB,18:36')]
+    procedure TestTimeConversion(const locale: String; const text: String);
 
-	[Test]
-	[TestCase('EN-US local format, verbose',        'EN-US,06/22/2020 06:36:00 pm')]
-	[TestCase('EN-US local format short',           'EN-US,6/22/2020 6:36 pm')]
-	[TestCase('EN-US iso 8601 format',              'EN-US,2020-06-22 18:36:00')]
-	[TestCase('EN-US iso 8601 format, verbose',     'EN-US,2020-06-22T18:36:00.000Z')]
-	[TestCase('EN-GB local format, 24 h, verbose',  'EN-GB,22/06/2020 18:36:00')]
-	[TestCase('EN-GB local format, 12 h, verbose',  'EN-GB,22/06/2020 06:36:00 pm')]
-	[TestCase('EN-GB iso8601 format',               'EN-GB,2020-06-22 18:36')]
-	[TestCase('EN-GB iso8601 format, verbose',      'EN-GB,2020-06-22T18:36:00+00')]
-	[TestCase('DE local format, verbose',           'DE,22.06.2020 18:36:00.000')]
-	[TestCase('DE local format, short',             'DE,22.6.20 18:36')]
-	[TestCase('DE iso8601 format',                  'DE,2020-06-22 18:36:00')]
-	procedure TestDateTimeConversion(const locale: String; const text: String);
+    [Test]
+    [TestCase('EN-US local format, verbose',        'EN-US,06/22/2020 06:36:00 pm')]
+    [TestCase('EN-US local format short',           'EN-US,6/22/2020 6:36 pm')]
+    [TestCase('EN-US iso 8601 format',              'EN-US,2020-06-22 18:36:00')]
+    [TestCase('EN-US iso 8601 format, verbose',     'EN-US,2020-06-22T18:36:00.000Z')]
+    [TestCase('EN-GB local format, 24 h, verbose',  'EN-GB,22/06/2020 18:36:00')]
+    [TestCase('EN-GB local format, 12 h, verbose',  'EN-GB,22/06/2020 06:36:00 pm')]
+    [TestCase('EN-GB iso8601 format',               'EN-GB,2020-06-22 18:36')]
+    [TestCase('EN-GB iso8601 format, verbose',      'EN-GB,2020-06-22T18:36:00+00')]
+    [TestCase('DE local format, verbose',           'DE,22.06.2020 18:36:00.000')]
+    [TestCase('DE local format, short',             'DE,22.6.20 18:36')]
+    [TestCase('DE iso8601 format',                  'DE,2020-06-22 18:36:00')]
+    procedure TestDateTimeConversion(const locale: String; const text: String);
   end;
 
 implementation uses
@@ -77,15 +85,20 @@ implementation uses
 
 { TMyExampleTests }
 
-constructor TValueHelperTests.Create();
+procedure TValueHelperTests.AfterConstruction;
 begin
-	inherited;
+ 	inherited;
+  {$IFDEF DELPHI_XE_UP}
 	originalFormatSettings := {$IFDEF USE_NS}System.{$ENDIF}SysUtils.FormatSettings;
+  {$ELSE}
+  originalLCID := GetThreadLocale;
+  {$ENDIF}
+
 	expectedDate := EncodeDate(2020, 06, 22);
 	expectedTime := EncodeTime(18, 36, 00, 000);
 end;
 
-destructor TValueHelperTests.Destroy();
+destructor TValueHelperTests.Destroy;
 begin
   revertFormatSettings();
   inherited;
@@ -93,18 +106,45 @@ end;
 
 procedure TValueHelperTests.revertFormatSettings();
 begin
+  {$IFDEF DELPHI_XE_UP}
 	{$IFDEF USE_NS}System.{$ENDIF}SysUtils.FormatSettings := originalFormatSettings;
+  {$ELSE}
+  SetThreadLocale(originalLCID);
+	GetFormatSettings;
+  {$ENDIF}
 end;
 
+{$IFDEF DELPHI_2010_DOWN}
+// I could not find a better way than hardcode them for D2010..
+// Full list: https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a
+function TValueHelperTests.GetLCIDFromLocale(const locale: string): integer;
+begin
+  if locale = 'EN-US' then
+    result := 1033
+  else if locale = 'EN-GB' then
+    result := 2057
+  else if locale = 'DE' then
+    result := 1031
+  else
+    raise Exception.Create('Unsupported locale passed to GetLCIDFromLocale function');
+end;
+{$ENDIF}
+
 procedure TValueHelperTests.setFormatSettings(const locale: String);
-{$If Defined(XE2_DOWN)}
+{$If Defined(DELPHI_XE2_DOWN)}
 var
 	_lcid: LCID;
 {$IFEND}
 begin
-	{$If Defined(XE2_DOWN)}
-	_lcid := LocaleNameToLCID(PChar(locale), 0);
-	GetLocaleFormatSettings(_lcid, FormatSettings);
+	{$If Defined(DELPHI_XE2_DOWN)}
+    {$IFDEF DELPHI_2010_DOWN}
+    _lcid := GetLCIDFromLocale(locale);
+    SetThreadLocale(_lcid);
+  	GetFormatSettings;
+    {$ELSE}
+    _lcid := LocaleNameToLCID(PChar(locale), 0);
+  	GetLocaleFormatSettings(_lcid, FormatSettings);
+    {$ENDIF}
 	{$Else}
 	FormatSettings := TFormatSettings.Create(locale);
 	{$IFEND}
@@ -149,5 +189,8 @@ begin
 	actual := asTValue.AsType<TTime>();
 	Assert.IsTrue( SameTime(expectedTime, actual), 'SameTime(..)' );
 end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TValueHelperTests);
 
 end.

--- a/Tests/DUnitXTest_D2010.dpr
+++ b/Tests/DUnitXTest_D2010.dpr
@@ -66,7 +66,8 @@ uses
   DUnitX.Tests.Inheritance in 'DUnitX.Tests.Inheritance.pas',
   DUnitX.Tests.ConsoleWriter.Base in 'DUnitX.Tests.ConsoleWriter.Base.pas',
   DUnitX.Assert in '..\Source\DUnitX.Assert.pas',
-  DUnitX.Types in '..\Source\DUnitX.Types.pas';
+  DUnitX.Types in '..\Source\DUnitX.Types.pas',
+  DUnitX.Tests.Utils in 'DUnitX.Tests.Utils.pas';
 
 var
   runner : ITestRunner;

--- a/Tests/DUnitXTest_D2010.dpr
+++ b/Tests/DUnitXTest_D2010.dpr
@@ -1,0 +1,130 @@
+program DUnitXTest_D2010;
+
+{$IFNDEF GUI}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+
+{$STRONGLINKTYPES OFF}
+
+uses
+  SysUtils,
+  DUnitX.Loggers.GUI.VCL in '..\Source\DUnitX.Loggers.GUI.VCL.pas' {GUIVCLTestRunner},
+  DUnitX.Loggers.Console in '..\Source\DUnitX.Loggers.Console.pas',
+  DUnitX.Loggers.Text in '..\Source\DUnitX.Loggers.Text.pas',
+  DUnitX.MacOS.Console in '..\Source\DUnitX.MacOS.Console.pas',
+  DUnitX.Windows.Console in '..\Source\DUnitX.Windows.Console.pas',
+  DUnitX.ConsoleWriter.Base in '..\Source\DUnitX.ConsoleWriter.Base.pas',
+  DUnitX.Loggers.XML.xUnit in '..\Source\DUnitX.Loggers.XML.xUnit.pas',
+  DUnitX.Generics in '..\Source\DUnitX.Generics.pas',
+  DUnitX.Utils in '..\Source\DUnitX.Utils.pas',
+  DUnitX.WeakReference in '..\Source\DUnitX.WeakReference.pas',
+  DUnitX.Test in '..\Source\DUnitX.Test.pas',
+  DUnitX.TestFixture in '..\Source\DUnitX.TestFixture.pas',
+  DUnitX.TestResult in '..\Source\DUnitX.TestResult.pas',
+  DUnitX.RunResults in '..\Source\DUnitX.RunResults.pas',
+  DUnitX.TestRunner in '..\Source\DUnitX.TestRunner.pas',
+  DUnitX.InternalInterfaces in '..\Source\DUnitX.InternalInterfaces.pas',
+  DUnitX.TestFramework in '..\Source\DUnitX.TestFramework.pas',
+  DUnitX.DUnitCompatibility in '..\Source\DUnitX.DUnitCompatibility.pas',
+  DUnitX.IoC in '..\Source\DUnitX.IoC.pas',
+  DUnitX.Utils.XML in '..\Source\DUnitX.Utils.XML.pas',
+  DUnitX.StackTrace.JCL in '..\Source\DUnitX.StackTrace.JCL.pas',
+  DUnitX.StackTrace.MadExcept3 in '..\Source\DUnitX.StackTrace.MadExcept3.pas',
+  DUnitX.StackTrace.MadExcept4 in '..\Source\DUnitX.StackTrace.MadExcept4.pas',
+  DUnitX.StackTrace.EurekaLog7 in '..\Source\DUnitX.StackTrace.EurekaLog7.pas',
+  DUnitX.Loggers.Null in '..\Source\DUnitX.Loggers.Null.pas',
+  DUnitX.FixtureResult in '..\Source\DUnitX.FixtureResult.pas',
+  DUnitX.Tests.Assert in 'DUnitX.Tests.Assert.pas',
+  DUnitX.Tests.DUnitCompatibility in 'DUnitX.Tests.DUnitCompatibility.pas',
+  DUnitX.Tests.Example in 'DUnitX.Tests.Example.pas',
+  DUnitX.Tests.Framework in 'DUnitX.Tests.Framework.pas',
+  DUnitX.Tests.IoC in 'DUnitX.Tests.IoC.pas',
+  DUnitX.Tests.TestFixture in 'DUnitX.Tests.TestFixture.pas',
+  DUnitX.Tests.Utils.XML in 'DUnitX.Tests.Utils.XML.pas',
+  DUnitX.Tests.WeakReference in 'DUnitX.Tests.WeakReference.pas',
+  DUnitX.Tests.Loggers.XML.NUnit in 'DUnitX.Tests.Loggers.XML.NUnit.pas',
+  DUnitX.Loggers.XML.NUnit in '..\Source\DUnitX.Loggers.XML.NUnit.pas',
+  DUnitX.SingleNameSpace in 'DUnitX.SingleNameSpace.pas',
+  DUnitX.MemoryLeakMonitor.Default in '..\Source\DUnitX.MemoryLeakMonitor.Default.pas',
+  DUnitX.MemoryLeakMonitor.FastMM4 in '..\Source\DUnitX.MemoryLeakMonitor.FastMM4.pas',
+  DUnitX.Tests.MemoryLeaks in 'DUnitX.Tests.MemoryLeaks.pas',
+  DUnitX.Extensibility in '..\Source\DUnitX.Extensibility.pas',
+  DUnitX.Extensibility.PluginManager in '..\Source\DUnitX.Extensibility.PluginManager.pas',
+  DUnitX.FixtureProviderPlugin in '..\Source\DUnitX.FixtureProviderPlugin.pas',
+  DUnitX.Tests.CommandLineParser in 'DUnitX.Tests.CommandLineParser.pas',
+  DUnitX.Filters in '..\Source\DUnitX.Filters.pas',
+  DUnitX.CategoryExpression in '..\Source\DUnitX.CategoryExpression.pas',
+  DUnitX.Tests.CategoryParser in 'DUnitX.Tests.CategoryParser.pas',
+  DUnitX.TestNameParser in '..\Source\DUnitX.TestNameParser.pas',
+  DUnitX.Tests.TestNameParser in 'DUnitX.Tests.TestNameParser.pas',
+  DUnitX.AutoDetect.Console in '..\Source\DUnitX.AutoDetect.Console.pas',
+  DUnitX.CommandLine.OptionDef in '..\Source\DUnitX.CommandLine.OptionDef.pas',
+  DUnitX.CommandLine.Options in '..\Source\DUnitX.CommandLine.Options.pas',
+  DUnitX.CommandLine.Parser in '..\Source\DUnitX.CommandLine.Parser.pas',
+  DUnitX.OptionsDefinition in '..\Source\DUnitX.OptionsDefinition.pas',
+  DUnitX.FilterBuilder in '..\Source\DUnitX.FilterBuilder.pas',
+  DUnitX.Tests.Inheritance in 'DUnitX.Tests.Inheritance.pas',
+  DUnitX.Tests.ConsoleWriter.Base in 'DUnitX.Tests.ConsoleWriter.Base.pas',
+  DUnitX.Assert in '..\Source\DUnitX.Assert.pas',
+  DUnitX.Types in '..\Source\DUnitX.Types.pas';
+
+var
+  runner : ITestRunner;
+  results : IRunResults;
+  logger : ITestLogger;
+  nunitLogger : ITestLogger;
+begin
+{$IFDEF GUI}
+  DUnitX.Loggers.GUI.VCL.Run;
+  exit;
+{$ENDIF}
+
+  try
+    TDUnitX.CheckCommandLine;
+    //Create the runner
+    runner := TDUnitX.CreateRunner;
+    runner.UseRTTI := True;
+    runner.FailsOnNoAsserts := True; //Assertions must be made during tests;
+    TDUnitX.Options.ExitBehavior := TDUnitXExitBehavior.Pause;
+
+    //tell the runner how we will log things
+
+    if TDUnitX.Options.ConsoleMode <> TDunitXConsoleMode.Off then
+    begin
+      logger := TDUnitXConsoleLogger.Create(TDUnitX.Options.ConsoleMode = TDunitXConsoleMode.Quiet);
+      runner.AddLogger(logger);
+    end;
+
+    nunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    runner.AddLogger(nunitLogger);
+
+    logger := nil;
+    nunitLogger := nil;
+    //Run tests
+    results := runner.Execute;
+    runner := nil;
+    //Let the CI Server know that something failed.
+
+    {$IFDEF CI}
+    if not results.AllPassed then
+      System.ExitCode := EXIT_ERRORS;
+    {$ELSE}
+    //We don;t want this happening when running under CI.
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done...  Press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+    results := nil;
+
+  except
+    on E: Exception do
+    begin
+      System.Writeln(E.ClassName, ': ', E.Message);
+      {$IFNDEF CI}
+      System.Readln;
+      {$ENDIF}
+    end;
+  end;
+end.

--- a/Tests/DUnitXTest_D2010.dproj
+++ b/Tests/DUnitXTest_D2010.dproj
@@ -1,0 +1,177 @@
+﻿	<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+		<PropertyGroup>
+			<Base>True</Base>
+			<AppType>Console</AppType>
+			<Config Condition="'$(Config)'==''">Debug</Config>
+			<DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
+			<FrameworkType>None</FrameworkType>
+			<MainSource>DUnitXTest_D2010.dpr</MainSource>
+			<Platform Condition="'$(Platform)'==''">Win32</Platform>
+			<Platform>Win32</Platform>
+			<ProjectGuid>{78AC97F9-EC37-4A68-8525-9C5EC2F94223}</ProjectGuid>
+			<ProjectVersion>14.6</ProjectVersion>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+			<Cfg_1>true</Cfg_1>
+			<CfgParent>Base</CfgParent>
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+			<Cfg_2>true</Cfg_2>
+			<CfgParent>Base</CfgParent>
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Base)'!=''">
+			<DCC_DependencyCheckOutputName>DUnitXTest_D2010.exe</DCC_DependencyCheckOutputName>
+			<DCC_ImageBase>00400000</DCC_ImageBase>
+			<DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
+			<DCC_Platform>x86</DCC_Platform>
+			<DCC_UnitSearchPath>..\Source;$(DelphiMocks);..\..\DelphiMocks;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+			<DCC_UsePackage>rtl;vcl;vclx;vclactnband;xmlrtl;vclimg;dbrtl;vcldb;vcldbx;bdertl;vcltouch;dsnap;dsnapcon;vclie;webdsnap;inet;inetdbbde;inetdbxpress;soaprtl;DbxCommonDriver;DbxClientDriver;DBXInterBaseDriver;DBXMySQLDriver;dbexpress;dbxcds;FBDream2010;SynEdit_R2010;NxCommonRun;NxGridRun;KWizardD2010R;GFDLIB2009;dclRouteMapD2010;tb2k_d12;SpTBXLib_d12;dwWin7Controls_2010;IndyCore140;IndySystem140;IndyProtocols140;lmddocking11rt_140;lmdrtl11rt_140;RaizeComponentsVcl;FBMiscComponents;FBFormDesigner;FBSynEditHighlighters;VSPageR;madBasic_;madDisAsm_;madExcept_;adortl;TeeWorld814;TeeImage814;TeeLanguage814;TeePro814;TeeGL814;TeeUI814;TeeDB814;Tee814;VirtualTreesR;VSMessageAPIDesign;VSMessageAPIRun;$(DCC_UsePackage)</DCC_UsePackage>
+			<Manifest_File>None</Manifest_File>
+			<VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+			<VerInfo_Locale>3081</VerInfo_Locale>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Cfg_1)'!=''">
+			<DCC_DebugInformation>false</DCC_DebugInformation>
+			<DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+			<DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Cfg_2)'!=''">
+			<DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+			<DCC_Define>DEBUG;DEBUG-DUNITX;$(DCC_Define)</DCC_Define>
+		</PropertyGroup>
+		<ItemGroup>
+			<DelphiCompile Include="DUnitXTest_D2010.dpr">
+				<MainSource>MainSource</MainSource>
+			</DelphiCompile>
+			<DCCReference Include="..\Source\DUnitX.Loggers.GUI.VCL.pas">
+				<Form>GUIVCLTestRunner</Form>
+			</DCCReference>
+			<DCCReference Include="..\Source\DUnitX.Loggers.Console.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Loggers.Text.pas"/>
+			<DCCReference Include="..\Source\DUnitX.MacOS.Console.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Windows.Console.pas"/>
+			<DCCReference Include="..\Source\DUnitX.ConsoleWriter.Base.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Loggers.XML.xUnit.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Generics.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Utils.pas"/>
+			<DCCReference Include="..\Source\DUnitX.WeakReference.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Test.pas"/>
+			<DCCReference Include="..\Source\DUnitX.TestFixture.pas"/>
+			<DCCReference Include="..\Source\DUnitX.TestResult.pas"/>
+			<DCCReference Include="..\Source\DUnitX.RunResults.pas"/>
+			<DCCReference Include="..\Source\DUnitX.TestRunner.pas"/>
+			<DCCReference Include="..\Source\DUnitX.InternalInterfaces.pas"/>
+			<DCCReference Include="..\Source\DUnitX.TestFramework.pas"/>
+			<DCCReference Include="..\Source\DUnitX.DUnitCompatibility.pas"/>
+			<DCCReference Include="..\Source\DUnitX.IoC.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Utils.XML.pas"/>
+			<DCCReference Include="..\Source\DUnitX.StackTrace.JCL.pas"/>
+			<DCCReference Include="..\Source\DUnitX.StackTrace.MadExcept3.pas"/>
+			<DCCReference Include="..\Source\DUnitX.StackTrace.MadExcept4.pas"/>
+			<DCCReference Include="..\Source\DUnitX.StackTrace.EurekaLog7.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Loggers.Null.pas"/>
+			<DCCReference Include="..\Source\DUnitX.FixtureResult.pas"/>
+			<DCCReference Include="DUnitX.Tests.Assert.pas"/>
+			<DCCReference Include="DUnitX.Tests.DUnitCompatibility.pas"/>
+			<DCCReference Include="DUnitX.Tests.Example.pas"/>
+			<DCCReference Include="DUnitX.Tests.Framework.pas"/>
+			<DCCReference Include="DUnitX.Tests.IoC.pas"/>
+			<DCCReference Include="DUnitX.Tests.TestFixture.pas"/>
+			<DCCReference Include="DUnitX.Tests.Utils.XML.pas"/>
+			<DCCReference Include="DUnitX.Tests.WeakReference.pas"/>
+			<DCCReference Include="DUnitX.Tests.Loggers.XML.NUnit.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Loggers.XML.NUnit.pas"/>
+			<DCCReference Include="DUnitX.SingleNameSpace.pas"/>
+			<DCCReference Include="..\Source\DUnitX.MemoryLeakMonitor.Default.pas"/>
+			<DCCReference Include="..\Source\DUnitX.MemoryLeakMonitor.FastMM4.pas"/>
+			<DCCReference Include="DUnitX.Tests.MemoryLeaks.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Extensibility.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Extensibility.PluginManager.pas"/>
+			<DCCReference Include="..\Source\DUnitX.FixtureProviderPlugin.pas"/>
+			<DCCReference Include="DUnitX.Tests.CommandLineParser.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Filters.pas"/>
+			<DCCReference Include="..\Source\DUnitX.CategoryExpression.pas"/>
+			<DCCReference Include="DUnitX.Tests.CategoryParser.pas"/>
+			<DCCReference Include="..\Source\DUnitX.TestNameParser.pas"/>
+			<DCCReference Include="DUnitX.Tests.TestNameParser.pas"/>
+			<DCCReference Include="..\Source\DUnitX.AutoDetect.Console.pas"/>
+			<DCCReference Include="..\Source\DUnitX.CommandLine.OptionDef.pas"/>
+			<DCCReference Include="..\Source\DUnitX.CommandLine.Options.pas"/>
+			<DCCReference Include="..\Source\DUnitX.CommandLine.Parser.pas"/>
+			<DCCReference Include="..\Source\DUnitX.OptionsDefinition.pas"/>
+			<DCCReference Include="..\Source\DUnitX.FilterBuilder.pas"/>
+			<DCCReference Include="DUnitX.Tests.Inheritance.pas"/>
+			<DCCReference Include="DUnitX.Tests.ConsoleWriter.Base.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Assert.pas"/>
+			<DCCReference Include="..\Source\DUnitX.Types.pas"/>
+			<None Include="..\Source\DUnitX.inc"/>
+			<None Include="..\Source\DUnitX.Stacktrace.inc"/>
+			<None Include="..\Source\DUnitX.MemoryLeaks.inc"/>
+			<BuildConfiguration Include="Base">
+				<Key>Base</Key>
+			</BuildConfiguration>
+			<BuildConfiguration Include="Release">
+				<Key>Cfg_1</Key>
+				<CfgParent>Base</CfgParent>
+			</BuildConfiguration>
+			<BuildConfiguration Include="Debug">
+				<Key>Cfg_2</Key>
+				<CfgParent>Base</CfgParent>
+			</BuildConfiguration>
+		</ItemGroup>
+		<Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+		<ProjectExtensions>
+			<Borland.Personality>Delphi.Personality.12</Borland.Personality>
+			<Borland.ProjectType>VCLApplication</Borland.ProjectType>
+			<BorlandProject>
+				<Delphi.Personality>
+					<Source>
+						<Source Name="MainSource">DUnitXTest_D2010.dpr</Source>
+					</Source>
+					<Excluded_Packages/>
+					<VersionInfo>
+						<VersionInfo Name="IncludeVerInfo">False</VersionInfo>
+						<VersionInfo Name="AutoIncBuild">False</VersionInfo>
+						<VersionInfo Name="MajorVer">1</VersionInfo>
+						<VersionInfo Name="MinorVer">0</VersionInfo>
+						<VersionInfo Name="Release">0</VersionInfo>
+						<VersionInfo Name="Build">0</VersionInfo>
+						<VersionInfo Name="Debug">False</VersionInfo>
+						<VersionInfo Name="PreRelease">False</VersionInfo>
+						<VersionInfo Name="Special">False</VersionInfo>
+						<VersionInfo Name="Private">False</VersionInfo>
+						<VersionInfo Name="DLL">False</VersionInfo>
+						<VersionInfo Name="Locale">3081</VersionInfo>
+						<VersionInfo Name="CodePage">1252</VersionInfo>
+					</VersionInfo>
+					<VersionInfoKeys>
+						<VersionInfoKeys Name="CompanyName"/>
+						<VersionInfoKeys Name="FileDescription"/>
+						<VersionInfoKeys Name="FileVersion">1.0.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="InternalName"/>
+						<VersionInfoKeys Name="LegalCopyright"/>
+						<VersionInfoKeys Name="LegalTrademarks"/>
+						<VersionInfoKeys Name="OriginalFilename"/>
+						<VersionInfoKeys Name="ProductName"/>
+						<VersionInfoKeys Name="ProductVersion">1.0.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="Comments"/>
+					</VersionInfoKeys>
+					<Parameters>
+						<Parameters Name="UseLauncher">False</Parameters>
+						<Parameters Name="LoadAllSymbols">True</Parameters>
+						<Parameters Name="LoadUnspecifiedSymbols">False</Parameters>
+					</Parameters>
+				</Delphi.Personality>
+				<Platforms>
+					<Platform value="Win32">True</Platform>
+				</Platforms>
+			</BorlandProject>
+			<ProjectFileVersion>12</ProjectFileVersion>
+		</ProjectExtensions>
+	</Project>

--- a/Tests/DUnitXTest_D2010.dproj
+++ b/Tests/DUnitXTest_D2010.dproj
@@ -2,7 +2,7 @@
 		<PropertyGroup>
 			<Base>True</Base>
 			<AppType>Console</AppType>
-			<Config Condition="'$(Config)'==''">Debug</Config>
+			<Config Condition="'$(Config)'==''">GUI</Config>
 			<DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
 			<FrameworkType>None</FrameworkType>
 			<MainSource>DUnitXTest_D2010.dpr</MainSource>
@@ -24,6 +24,12 @@
 			<CfgParent>Base</CfgParent>
 			<Base>true</Base>
 		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='GUI' or '$(Cfg_3)'!=''">
+			<Cfg_3>true</Cfg_3>
+			<CfgParent>Cfg_2</CfgParent>
+			<Cfg_2>true</Cfg_2>
+			<Base>true</Base>
+		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
 			<DCC_DependencyCheckOutputName>DUnitXTest_D2010.exe</DCC_DependencyCheckOutputName>
 			<DCC_ImageBase>00400000</DCC_ImageBase>
@@ -42,8 +48,12 @@
 			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Cfg_2)'!=''">
+			<DCC_DebugDCUs>true</DCC_DebugDCUs>
 			<DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
 			<DCC_Define>DEBUG;DEBUG-DUNITX;$(DCC_Define)</DCC_Define>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Cfg_3)'!=''">
+			<DCC_Define>GUI;$(DCC_Define)</DCC_Define>
 		</PropertyGroup>
 		<ItemGroup>
 			<DelphiCompile Include="DUnitXTest_D2010.dpr">
@@ -110,11 +120,16 @@
 			<DCCReference Include="DUnitX.Tests.ConsoleWriter.Base.pas"/>
 			<DCCReference Include="..\Source\DUnitX.Assert.pas"/>
 			<DCCReference Include="..\Source\DUnitX.Types.pas"/>
+			<DCCReference Include="DUnitX.Tests.Utils.pas"/>
 			<None Include="..\Source\DUnitX.inc"/>
 			<None Include="..\Source\DUnitX.Stacktrace.inc"/>
 			<None Include="..\Source\DUnitX.MemoryLeaks.inc"/>
 			<BuildConfiguration Include="Base">
 				<Key>Base</Key>
+			</BuildConfiguration>
+			<BuildConfiguration Include="GUI">
+				<Key>Cfg_3</Key>
+				<CfgParent>Cfg_2</CfgParent>
 			</BuildConfiguration>
 			<BuildConfiguration Include="Release">
 				<Key>Cfg_1</Key>


### PR DESCRIPTION
Since the company I work at are still on D2010 and we find ourselves using DUnitX more and more I made some fixes so we can execute the tests:
- Create a project for the Delphi 2010 to run the tests.
- Ensure all included files can compile and tests are successful (except the items below)

Issues:
- `DUnitX.Tests.Example.TXampleFixture3` fails, it would seem there is an issue with `[SetupFixture]` with D2010, I have not been able to locate the issue
![image](https://user-images.githubusercontent.com/16911399/133455630-fc218c16-df41-47d9-9db9-93e72f55f525.png)
- `[MaxTime]` also does not seem to work as it hangs the test, I have not investigated further for the time being and flagged the test as `[Ignore]` for D2010