### PR TITLE
Fix FormatSetting not getting setup for versions lower than XE

### DIFF
--- a/Source/DUnitX.Loggers.XML.JUnit.pas
+++ b/Source/DUnitX.Loggers.XML.JUnit.pas
@@ -97,9 +97,10 @@ begin
   inherited Create;
   {$IFDEF DELPHI_XE_UP }
   FFormatSettings := TFormatSettings.Create;
+  {$ENDIF}
   FFormatSettings.ThousandSeparator := ',';
   FFormatSettings.DecimalSeparator := '.';
-  {$ELSE}
+  {$IFNDEF DELPHI_XE_UP}
   oldThousandSeparator        := {$IFDEF USE_NS}System.{$ENDIF}SysUtils.ThousandSeparator;
   oldDecimalSeparator         := {$IFDEF USE_NS}System.{$ENDIF}DecimalSeparator;
   try

--- a/Source/DUnitX.Loggers.XML.NUnit.pas
+++ b/Source/DUnitX.Loggers.XML.NUnit.pas
@@ -98,9 +98,10 @@ begin
   inherited Create;
   {$IFDEF DELPHI_XE_UP }
   FFormatSettings := TFormatSettings.Create;
+  {$ENDIF}
   FFormatSettings.ThousandSeparator := ',';
   FFormatSettings.DecimalSeparator := '.';
-  {$ELSE}
+  {$IFNDEF DELPHI_XE_UP}
   oldThousandSeparator        := {$IFDEF USE_NS}System.{$ENDIF}SysUtils.ThousandSeparator;
   oldDecimalSeparator         := {$IFDEF USE_NS}System.{$ENDIF}DecimalSeparator;
   try


### PR DESCRIPTION
While TFormatSettings cannot be created in non-XE version (it is a record) it is still passed in the .Format function so it needs to be setup.
The behavior that made me notice the issue is that the time taken for tests in the XML did not have decimals (they seemed to be in ms but in fact simply did not have a decimal separator).