### PR TITLE
Improve Assert.NoDiff

### DIFF
--- a/Source/DUnitX.Assert.pas
+++ b/Source/DUnitX.Assert.pas
@@ -971,37 +971,42 @@ begin
 end;
 
 class procedure Assert.NoDiff(const expected, actual: string; const ignoreCase : boolean; const message: string);
-const
-  DIFF_LENGTH = 10;
+
+  procedure FailSubstring(position: integer);
+  const
+    DIFF_LENGTH = 10;
+  begin
+    FailFmt(SDiffAtPosition + ': ' + SStrDoesNotMatch, [position,
+      TStrUtils.EncodeWhitespace(Copy(expected, position, DIFF_LENGTH)),
+      TStrUtils.EncodeWhitespace(Copy(actual, position, DIFF_LENGTH)), message]);
+  end;
+
 var
-  lenExp, lenAct: integer;
+  lenExp, lenAct, lenCmp: integer;
   strExp, strAct: string;
   position: Integer;
 begin
   DoAssert;
   lenExp := Length(expected);
   lenAct := Length(actual);
+  lenCmp := Min(lenExp, lenAct);
 
-  if lenExp <> lenAct then
-    FailFmt(SLengthOfStringsNotEqual + ': ' + SUnexpectedErrorInt, [lenExp, lenAct, message])
+  if ignoreCase then
+  begin
+    strExp := UpperCase(expected);
+    strAct := UpperCase(actual);
+  end
   else begin
-    if ignoreCase then
-    begin
-      strExp := UpperCase(expected);
-      strAct := UpperCase(actual);
-    end
-    else begin
-      strExp := expected;
-      strAct := actual;
-    end;
-    for position := 1 to lenExp do
-    begin
-      if (position <= lenAct) and (strExp[position] <> strAct[position]) then
-        FailFmt(SDiffAtPosition + ': ' + SStrDoesNotMatch, [position,
-          TStrUtils.EncodeWhitespace(Copy(expected, position, DIFF_LENGTH)),
-          TStrUtils.EncodeWhitespace(Copy(actual, position, DIFF_LENGTH)), message]);
-    end;
+    strExp := expected;
+    strAct := actual;
   end;
+  for position := 1 to lenCmp do
+  begin
+    if strExp[position] <> strAct[position] then
+      FailSubstring(position);
+  end;
+  if lenExp <> lenAct then
+    FailSubstring(lenCmp + 1);
 end;
 
 class procedure Assert.NoDiff(const expected, actual, message: string);

--- a/Source/DUnitX.Assert.pas
+++ b/Source/DUnitX.Assert.pas
@@ -724,7 +724,7 @@ end;
 
 class procedure Assert.FailFmt(const message: string; const args: array of const; const errorAddrs: pointer);
 begin
-  Fail(Format(message, args), errorAddrs);
+  Fail(Trim(Format(message, args)), errorAddrs);
 end;
 
 class procedure Assert.Pass(const message: string);

--- a/Source/DUnitX.ResStrs.pas
+++ b/Source/DUnitX.ResStrs.pas
@@ -92,7 +92,6 @@ resourcestring
   SStrCannotBeEmpty = 'subString cannot be empty';
   SStrDoesNotStartWith = '[%s] does not start with [%s] %s';
   SNumberOfStringsNotEqual = 'Number of strings is not equal';
-  SLengthOfStringsNotEqual = 'Length of strings is not equal';
   SDiffAtPosition = 'Difference at position %d';
   SCheckEmptyExpectation = 'Expectation not achieved [%s] %s';
 

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -106,12 +106,37 @@ type
     [TestCase('Length',
       '  '#8',' +
       ' ,' +
-      'Length of strings is not equal: Expected [3] but got [1] ',
+      'Difference at position 2: ['' ''#8] does not match [] ',
+      ',', false)]
+    [TestCase('First Char',
+      'Lorem ipsum,' +
+      'lorem ipsum,' +
+      'Difference at position 1: [''Lorem ipsu''] does not match [''lorem ipsu''] ',
+      ',', false)]
+    [TestCase('Last Char',
+      'Lorem ipsum,' +
+      'Lorem ipsuM,' +
+      'Difference at position 11: [''m''] does not match [''M''] ',
+      ',', false)]
+    [TestCase('A sub B',
+      'Lorem ip,' +
+      'Lorem ipsum,' +
+      'Difference at position 9: [] does not match [''sum''] ',
+      ',', false)]
+    [TestCase('B sub A',
+      'Lorem ipsum,' +
+      'Lorem ip,' +
+      'Difference at position 9: [''sum''] does not match [] ',
+      ',', false)]
+    [TestCase('Tab vs Space',
+      'lorem ipsum,' +
+      'lorem'#9'ipsum,' +
+      'Difference at position 6: ['' ipsum''] does not match [#9''ipsum''] ',
       ',', false)]
     [TestCase('Different Spaces',
       'lorem ipsum,' +
       'lorem  ipsum,' +
-      'Length of strings is not equal: Expected [11] but got [12] characters,characters',
+      'Difference at position 7: [''ipsum''] does not match ['' ipsum''] ',
       ',', false)]
     [TestCase('Capitalization',
       'lorem ipsum,'+

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -96,10 +96,39 @@ type
     procedure AreEqual_TClass_Throws_ETestFailure_When_Classes_Are_NotEqual;
 
     [Test]
-    procedure NoDiff_Throws_No_Exception_When_Strings_Are_Equal;
+    [TestCase('Empty', ',')]
+    [TestCase('CR', #13','#13)]
+    [TestCase('Simple','abc,abc')]
+    [TestCase('Ignore case simple','abc,ABC,true')]
+    [TestCase('Ignore case complex','LoReM iPsUm DoLoR sIt AmEt,lOrEm IpSuM dOlOr SiT aMeT,true')]
+    procedure NoDiff_Throws_No_Exception_When_Strings_Are_Equal(const A, B: string; AIgnoreCase:boolean = false);
 
-    [Test]
-    procedure NoDiff_Throws_ETestFailure_When_Strings_Are_NotEqual;
+    [TestCase('Length',
+      '  '#8',' +
+      ' ,' +
+      'Length of strings is not equal: Expected [3] but got [1] ',
+      ',', false)]
+    [TestCase('Different Spaces',
+      'lorem ipsum,' +
+      'lorem  ipsum,' +
+      'Length of strings is not equal: Expected [11] but got [12] characters,characters',
+      ',', false)]
+    [TestCase('Capitalization',
+      'lorem ipsum,'+
+      'lorem Ipsum,' +
+      'Difference at position 7: [''ipsum''] does not match [''Ipsum''] ',
+      ',', false)]
+    [TestCase('CR vs LF',
+      #13',' +
+      #10',' +
+      'Difference at position 1: [#13] does not match [#10] ',
+      ',', false)]
+    [TestCase('TAB vs CR',
+      'lorem ipsum'#9' ,' +
+      'lorem'#13'ipsum'#13#10',' +
+      'Difference at position 6: ['' ipsum''#9'' ''] does not match [#13''ipsum''#13#10] ',
+      ',', false)]
+    procedure NoDiff_Throws_ETestFailure_When_Strings_Are_NotEqual(const A, B, AException, AMessage : string);
 
     [Test]
     procedure AreEqual_TStrings_Throws_No_Exception_When_Strings_Are_Equal;
@@ -418,59 +447,19 @@ begin
   end;
 end;
 
-procedure TTestsAssert.NoDiff_Throws_ETestFailure_When_Strings_Are_NotEqual;
+procedure TTestsAssert.NoDiff_Throws_ETestFailure_When_Strings_Are_NotEqual(const A, B, AException, AMessage : string);
 begin
   Assert.WillRaiseWithMessage(procedure
     begin
-      Assert.NoDiff('  '#8, ' ');
-    end, ETestFailure, 'Length of strings is not equal: Expected [3] but got [1] ');
-
-  Assert.WillRaiseWithMessage(procedure
-    begin
-      Assert.NoDiff('lorem ipsum', 'lorem ipsum ', 'characters');
-    end,
-    ETestFailure, 'Length of strings is not equal: Expected [11] but got [12] characters');
-
-  Assert.WillRaiseWithMessage(procedure
-    begin
-      Assert.NoDiff('lorem ipsum', 'lorem Ipsum');
-    end,
-    ETestFailure, 'Difference at position 7: [''ipsum''] does not match [''Ipsum''] ');
-
-  Assert.WillRaiseWithMessage(procedure
-    begin
-      Assert.NoDiff(#13, #10);
-    end,
-    ETestFailure, 'Difference at position 1: [#13] does not match [#10] ');
-
-  Assert.WillRaiseWithMessage(procedure
-    begin
-      Assert.NoDiff('lorem ipsum'#9' ', 'lorem'#13'ipsum'#13#10);
-    end,
-    ETestFailure, 'Difference at position 6: ['' ipsum''#9'' ''] does not match [#13''ipsum''#13#10] ');
+      Assert.NoDiff(A, B, AMessage);
+    end, ETestFailure, AException);
 end;
 
-procedure TTestsAssert.NoDiff_Throws_No_Exception_When_Strings_Are_Equal;
+procedure TTestsAssert.NoDiff_Throws_No_Exception_When_Strings_Are_Equal(const A, B: string; AIgnoreCase:boolean = false);
 begin
   Assert.WillNotRaise(procedure
     begin
-      Assert.NoDiff('', '');
-    end);
-  Assert.WillNotRaise(procedure
-    begin
-      Assert.NoDiff(#13, #13);
-    end);
-  Assert.WillNotRaise(procedure
-    begin
-      Assert.NoDiff('abc', 'abc');
-    end);
-  Assert.WillNotRaise(procedure
-    begin
-      Assert.NoDiff('abc', 'ABC', true);
-    end);
-  Assert.WillNotRaise(procedure
-    begin
-      Assert.NoDiff('LoReM iPsUm DoLoR sIt AmEt', 'lOrEm IpSuM dOlOr SiT aMeT', true);
+      Assert.NoDiff(A,B,AIgnoreCase);
     end);
 end;
 

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -146,7 +146,7 @@ type
     [TestCase('CR vs LF',
       #13',' +
       #10',' +
-      'Difference at position 1: [#13] does not match [#10] ',
+      'Difference at position 1: [#13] does not match [#10] Linebreak style,Linebreak style',
       ',', false)]
     [TestCase('TAB vs CR',
       'lorem ipsum'#9' ,' +

--- a/Tests/DUnitX.Tests.Assert.pas
+++ b/Tests/DUnitX.Tests.Assert.pas
@@ -106,42 +106,42 @@ type
     [TestCase('Length',
       '  '#8',' +
       ' ,' +
-      'Difference at position 2: ['' ''#8] does not match [] ',
+      'Difference at position 2: ['' ''#8] does not match []',
       ',', false)]
     [TestCase('First Char',
       'Lorem ipsum,' +
       'lorem ipsum,' +
-      'Difference at position 1: [''Lorem ipsu''] does not match [''lorem ipsu''] ',
+      'Difference at position 1: [''Lorem ipsu''] does not match [''lorem ipsu'']',
       ',', false)]
     [TestCase('Last Char',
       'Lorem ipsum,' +
       'Lorem ipsuM,' +
-      'Difference at position 11: [''m''] does not match [''M''] ',
+      'Difference at position 11: [''m''] does not match [''M'']',
       ',', false)]
     [TestCase('A sub B',
       'Lorem ip,' +
       'Lorem ipsum,' +
-      'Difference at position 9: [] does not match [''sum''] ',
+      'Difference at position 9: [] does not match [''sum'']',
       ',', false)]
     [TestCase('B sub A',
       'Lorem ipsum,' +
       'Lorem ip,' +
-      'Difference at position 9: [''sum''] does not match [] ',
+      'Difference at position 9: [''sum''] does not match []',
       ',', false)]
     [TestCase('Tab vs Space',
       'lorem ipsum,' +
       'lorem'#9'ipsum,' +
-      'Difference at position 6: ['' ipsum''] does not match [#9''ipsum''] ',
+      'Difference at position 6: ['' ipsum''] does not match [#9''ipsum'']',
       ',', false)]
     [TestCase('Different Spaces',
       'lorem ipsum,' +
       'lorem  ipsum,' +
-      'Difference at position 7: [''ipsum''] does not match ['' ipsum''] ',
+      'Difference at position 7: [''ipsum''] does not match ['' ipsum'']',
       ',', false)]
     [TestCase('Capitalization',
       'lorem ipsum,'+
       'lorem Ipsum,' +
-      'Difference at position 7: [''ipsum''] does not match [''Ipsum''] ',
+      'Difference at position 7: [''ipsum''] does not match [''Ipsum'']',
       ',', false)]
     [TestCase('CR vs LF',
       #13',' +
@@ -151,7 +151,7 @@ type
     [TestCase('TAB vs CR',
       'lorem ipsum'#9' ,' +
       'lorem'#13'ipsum'#13#10',' +
-      'Difference at position 6: ['' ipsum''#9'' ''] does not match [#13''ipsum''#13#10] ',
+      'Difference at position 6: ['' ipsum''#9'' ''] does not match [#13''ipsum''#13#10]',
       ',', false)]
     procedure NoDiff_Throws_ETestFailure_When_Strings_Are_NotEqual(const A, B, AException, AMessage : string);
 
@@ -1053,7 +1053,7 @@ begin
     Assert.WillRaiseWithMessage(procedure
       begin
         Assert.AreEqual(expected, actual);
-      end, ETestFailure, 'Number of strings is not equal: Expected [3] but got [4] ');
+      end, ETestFailure, 'Number of strings is not equal: Expected [3] but got [4]');
 
     expected.CommaText := '"Lorem ipsum dolor sit amet","consectetur adipisici elit","sed eiusmod tempor incidunt"';
     actual.CommaText := '"Lorem ipsum dolor sit amet","consectetur adisipici elit","sed eiusmod tempor incidunt"';
@@ -1061,7 +1061,7 @@ begin
       begin
         Assert.AreEqual(expected, actual);
       end, ETestFailure,
-      'Difference at position 16: [''pisici eli''] does not match [''sipici eli''] at line 2 ');
+      'Difference at position 16: [''pisici eli''] does not match [''sipici eli''] at line 2');
   finally
     expected.Free;
     actual.Free;


### PR DESCRIPTION
It always bothered me that Assert.NoDiff didn't even attempt to compare when the length of the strings wasn't equal.
Did nobody ever have the case that A is a substring of B or that strings have different lengths but are identical up to a certain position?
Now Assert.NoDiff always compares. If no differences are found and the lengths aren't equal, the remainder is reported as difference.

While working on this, I added Trim() to the FailFmt function in order to get rid of the unnecessary trailing spaces, when no message is passed into the Assert. AFAICT this is not a breaking change for anybody else.