### PR TITLE
TestCaseAttribute does not work with parameters of type UInt64 and values > High(Int64)

### DIFF
--- a/Source/DUnitX.Utils.pas
+++ b/Source/DUnitX.Utils.pas
@@ -1214,7 +1214,10 @@ end;
 
 function ConvStr2Ord(const ASource: TValue; ATarget: PTypeInfo; out AResult: TValue): Boolean;
 begin
-  AResult := TValue.FromOrdinal(ATarget, StrToInt64Def(ASource.AsString, 0));
+  if ATarget = System.TypeInfo(UInt64) then
+    AResult := TValue.FromOrdinal(ATarget, StrToUInt64Def(ASource.AsString, 0))
+  else
+    AResult := TValue.FromOrdinal(ATarget, StrToInt64Def(ASource.AsString, 0));
   Result := True;
 end;
 

--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -62,6 +62,9 @@ type
     [TestCase('Case 3','5,6')]
     procedure TestOne(param1 : integer; param2 : integer);
 
+    [TestCase('UInt64 18446744073709551615', '18446744073709551615')]
+    procedure TestUint64Argument(Value: UInt64);
+
     [TestCase('Case 3','Blah,1')]
     procedure AnotherTestMethod(const a : string; const b : integer);
 
@@ -315,6 +318,11 @@ begin
   TDUnitX.CurrentRunner.Status('hello world');
   Assert.IsTrue(x is TObject); /// a bit pointless since it's strongly typed.
   x.Free;
+end;
+
+procedure TMyExampleTests.TestUint64Argument(Value: UInt64);
+begin
+  Assert.AreEqual(18446744073709551615, Value);
 end;
 
 destructor TExampleFixture2.Destroy;


### PR DESCRIPTION
fixes #332 