### PR TITLE
Fix DUnitXVCLGUI_D10Berlin.dproj compile (File not found "DUnitX.inc")

### DIFF
--- a/Examples/DUnitXExamples_D10Sydney.dproj
+++ b/Examples/DUnitXExamples_D10Sydney.dproj
@@ -111,7 +111,6 @@
         <DCC_Define>DUNITXDEBUG;madExcept;LeakChecking;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <VerInfo_Locale>1033</VerInfo_Locale>
-        <DCC_UnitSearchPath>..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win64)'!=''">
         <DCC_DebugDCUs>true</DCC_DebugDCUs>

--- a/Examples/DUnitXVCLGUI_D10Berlin.dproj
+++ b/Examples/DUnitXVCLGUI_D10Berlin.dproj
@@ -31,7 +31,9 @@
         <DCC_NO_RETVAL>error</DCC_NO_RETVAL>
         <DCC_CONSTRUCTING_ABSTRACT>error</DCC_CONSTRUCTING_ABSTRACT>
         <DCC_USE_BEFORE_DEF>error</DCC_USE_BEFORE_DEF>
-        <DCC_UnitSearchPath>..\;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
         <Manifest_File>None</Manifest_File>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>


### PR DESCRIPTION
+ removed redundant DCC_UnitSearchPath override in DUnitXExamples_D10Sydney.dproj