### PR TITLE
Fix: Memory leaks when displaying help (--help, -h)

### DIFF
--- a/Source/DUnitX.TestFramework.pas
+++ b/Source/DUnitX.TestFramework.pas
@@ -751,9 +751,6 @@ begin
   end
   else
   begin
-    //no parse errors, so now build the filter. will throw if there is an error.
-    FFilter := TDUnitXFilterBuilder.BuildFilter(FOptions);
-
     //Command line options parsed ok.
     if IsConsole then
     begin
@@ -764,9 +761,14 @@ begin
       begin
         consoleWriter := TDUnitXServiceLocator.DefaultContainer.Resolve<IDUnitXConsoleWriter>;
         ShowUsage(consoleWriter);
+        consoleWriter := nil;
+        parseResult := nil;
         Halt(EXIT_OK);
       end;
-    end
+    end;
+
+    //Build the filter only if we're actually going to run tests (not just showing help)
+    FFilter := TDUnitXFilterBuilder.BuildFilter(FOptions);
   end;
 
 end;


### PR DESCRIPTION
- Move FFilter build to after ShowUsage check to avoid creating TEmptyFilter unnecessarily when only showing help
- Clear interface references (consoleWriter, parseResult) before Halt to allow proper cleanup

Fixes leaks: TEmptyFilter, TCommandLineParseResult, TDUnitXWindowsConsoleWriter, TStringList