### PR TITLE
[Delphi XE3] Restoring compatibility of the DUnitX test project.

### DIFF
--- a/Tests/DUnitX.Tests.Example.pas
+++ b/Tests/DUnitX.Tests.Example.pas
@@ -65,8 +65,8 @@ type
     [TestCase('Case 3','5,6')]
     procedure TestOne(param1 : integer; param2 : integer);
 
-    [TestCase('UInt64 18446744073709551615', '18446744073709551615')]
-    procedure TestUint64Argument(Value: UInt64);
+    [Test]
+    procedure TestUint64Max;
 
     [TestCase('Case 3','Blah,1')]
     procedure AnotherTestMethod(const a : string; const b : integer);
@@ -340,9 +340,14 @@ begin
   x.Free;
 end;
 
-procedure TMyExampleTests.TestUint64Argument(Value: UInt64);
+procedure TMyExampleTests.TestUint64Max;
+const
+  UInt64MaxValue: UInt64 = 18446744073709551615;
+var
+  LUInt64Value: UInt64;
 begin
-  Assert.AreEqual(18446744073709551615, Value);
+  LUInt64Value:= High(UInt64);
+  Assert.AreEqual(UInt64MaxValue, LUInt64Value);
 end;
 
 destructor TExampleFixture2.Destroy;

--- a/Tests/DUnitX.Tests.Utils.pas
+++ b/Tests/DUnitX.Tests.Utils.pas
@@ -79,17 +79,18 @@ type
     [Test]
     [TestCase('EN-US local format, verbose',        'EN-US,06/22/2020 06:36:00 pm')]
     [TestCase('EN-US local format short',           'EN-US,6/22/2020 6:36 pm')]
-    [TestCase('EN-US iso 8601 format',              'EN-US,2020-06-22 18:36:00')]
-    [TestCase('EN-US iso 8601 format, verbose',     'EN-US,2020-06-22T18:36:00.000Z')]
     [TestCase('EN-GB local format, 24 h, verbose',  'EN-GB,22/06/2020 18:36:00')]
     [TestCase('EN-GB local format, 12 h, verbose',  'EN-GB,22/06/2020 06:36:00 pm')]
-    [TestCase('EN-GB iso8601 format',               'EN-GB,2020-06-22 18:36')]
-    [TestCase('EN-GB iso8601 format, verbose',      'EN-GB,2020-06-22T18:36:00+00')]
     [TestCase('DE local format, verbose',           'DE,22.06.2020 18:36:00.000')]
     [TestCase('DE local format, short',             'DE,22.6.20 18:36')]
+    {$IFDEF DELPHI_X8_UP}
+    [TestCase('EN-US iso 8601 format',              'EN-US,2020-06-22 18:36:00')]
+    [TestCase('EN-US iso 8601 format, verbose',     'EN-US,2020-06-22T18:36:00.000Z')]
+    [TestCase('EN-GB iso8601 format',               'EN-GB,2020-06-22 18:36')]
+    [TestCase('EN-GB iso8601 format, verbose',      'EN-GB,2020-06-22T18:36:00+00')]
     [TestCase('DE iso8601 format',                  'DE,2020-06-22 18:36:00')]
+    {$ENDIF}
     procedure TestDateTimeConversion2(const locale: String; const text: String);
-
 
     [Test]
     [TestCase('claRed = xFFFF0000',    'claRed,xFFFF0000')]

--- a/Tests/DUnitXTestProject.dpr
+++ b/Tests/DUnitXTestProject.dpr
@@ -14,6 +14,7 @@ uses
   DUnitX.Loggers.Console,
   DUnitX.Loggers.Xml.NUnit,
   {$ENDIF}
+  DunitX.Init,
   DUnitX.Tests.Assert in 'DUnitX.Tests.Assert.pas',
   DUnitX.Tests.DUnitCompatibility in 'DUnitX.Tests.DUnitCompatibility.pas',
   DUnitX.Tests.Example in 'DUnitX.Tests.Example.pas',


### PR DESCRIPTION
The test project was failing to compile and run on XE3 due to framework initialization requirements and the use of features not supported by that Delphi version.

Changes included in this PR:

- Added explicit initialization of the DUnitX framework in the test project entry point, as required for older Delphi versions.
- Adjusted the `UInt64` argument test to avoid internal `string` → `UInt64` conversions, which are not supported in Delphi XE3, while still validating the maximum `UInt64` value.
- Disabled ISO 8601 DateTime-related test cases for Delphi versions prior to XE8, since native ISO 8601 parsing is not available in XE3.

With these changes, the test project builds and executes correctly on Delphi XE3, without altering behavior for newer Delphi versions.

Closes #370