### PR TITLE
Undefine TESTINSIGHT if CI is defined in the DUnitX Expert CodeGen Template

### DIFF
--- a/Expert/DUnitX.Expert.CodeGen.Templates.pas
+++ b/Expert/DUnitX.Expert.CodeGen.Templates.pas
@@ -36,6 +36,9 @@ resourcestring
 
  STestDPR = 'program %0:s;'#13#10 +
  #13#10 +
+ '{$IFDEF CI}'#13#10 +
+ '{$UNDEF TESTINSIGHT}'#13#10 +
+ '{$ENDIF}'#13#10 +
  '{$IFNDEF TESTINSIGHT}'#13#10 +
  '{$APPTYPE CONSOLE}'#13#10 +
  '{$ENDIF}'#13#10 +


### PR DESCRIPTION
RE: https://github.com/VSoftTechnologies/DUnitX/issues/380

Automatically add to the top of each DPR:

{$IFDEF CI}
{$UNDEF TESTINSIGHT}
{$ENDIF}

Prevent editing DPR or having to create a dedicated CI build config