### PR TITLE
Ensure Execute uses a recently built fixtureslist

### DIFF
--- a/Source/DUnitX.TestRunner.pas
+++ b/Source/DUnitX.TestRunner.pas
@@ -581,8 +581,13 @@ var
 begin
   result := nil;
 
-  fixtures := BuildFixtures;
-  fixtureList := fixtures as ITestFixtureList;
+  if FFixtureList = nil then
+  begin
+    fixtures := BuildFixtures;
+    fixtureList := fixtures as ITestFixtureList;
+  end
+  else
+    fixtureList := FFixtureList;
   if fixtureList.Count = 0 then
     raise ENoTestsRegistered.Create(SNoFixturesFound);
 


### PR DESCRIPTION
A workflow of the following:

- Create a runner using `TDUnitX.CreateRunner`
- Call `BuildFixtures` on the runner and cast to `ITestFixtureList`
- Enable/disable fixtures/tests in the list
- Call `Execute` on the runner

Results in **all** tests being run. This is because `Execute` does not use the `ITestFixtureList` that was created earlier, but _rebuilds_ the fixture list, then executes them.

This PR modifies `Execute` to use the fixtures list that was previously built on the runner, if one exists, thus running only the fixtures/tests that were enabled. 