### PR TITLE
Allow the test to be ignored at runtime

### DIFF
--- a/Source/DUnitX.Exceptions.pas
+++ b/Source/DUnitX.Exceptions.pas
@@ -47,6 +47,8 @@ type
   //base exception for any internal exceptions which cause the test to stop
   EAbort = class(ETestFrameworkException);
 
+  ETestIgnored = class(ETestFrameworkException);
+
   ETestFailure = class(EAbort);
 
   ETestFailureStrCompare = class(ETestFailure)

--- a/Source/DUnitX.TestRunner.pas
+++ b/Source/DUnitX.TestRunner.pas
@@ -848,6 +848,8 @@ begin
 
       except
         //Handle the results which are raised in the test.
+        on e : ETestIgnored do
+          testResult := ExecuteIgnoredResult(context, threadId, test, test.IgnoreReason);
         on e : ETestPass do
           testResult := ExecuteSuccessfulResult(context, threadId, test, e.Message, FLogMessagesEx);
         on e : ETestFailure do


### PR DESCRIPTION
If, for any reason, a particular test is not yet ready to run, we can mark it as ignored. To do this, you need to mark the test in question with the `Ignore` attribute, for example:

``` pascal
[Test]
[Ignore('Test is not ready yet')]
procedure  VerifySomething();
```
This method allows you to ignore tests statically (at compile time).

The proposed modification also allows a given test to be skipped dynamically (at runtime). For example:
``` pascal
[Test] VerifySomething();
```

Test implementation:

``` pascal
uses
  DUnitX.Exceptions,

procedure TMyTestClass.VerifySomething();
begin
  if ImportantResourceIsUnavailable then
    raise ETestIgnored.Create('Important resource is unavailable');
    
  // resource is available - let's test it
  Assert.IsTrue(ImportantResource.Count > 0);
end;
```
