### PR TITLE
Fix and improve text file logger

### DIFF
--- a/Source/DUnitX.Loggers.Text.pas
+++ b/Source/DUnitX.Loggers.Text.pas
@@ -56,10 +56,11 @@ type
       fStartSuffix = ' - START';
       fStopSuffix  = ' - STOP';
     var
-      fOutput:  TStream;
-      fOwnOut:  Boolean;
-      fIndent:  Integer;
-      fIssues:  TStringList;
+      fOutput:   TStream;
+      fOwnOut:   Boolean;
+      fIndent:   Integer;
+      fIssues:   TStringList;
+      fEncoding: TEncoding;
 
     function GetFixtureName(const Fixture : ITestFixtureInfo) : string;
     function GetTestName(const Test : ITestInfo) : string;
@@ -92,7 +93,7 @@ type
     procedure OnTestingEnds(const RunResults : IRunResults); override;
 
   public
-    constructor Create(const outputStream : TStream; const ownsStream : Boolean = False);
+    constructor Create(const outputStream : TStream; const ownsStream : Boolean = False; encoding : TEncoding = nil);
     destructor Destroy(); override;
   end;
 
@@ -105,13 +106,18 @@ implementation
 
 {$REGION 'TDunitXTextLogger'}
 
-constructor TDunitXTextLogger.Create(const outputStream : TStream; const ownsStream : Boolean);
+constructor TDunitXTextLogger.Create(const outputStream : TStream; const ownsStream : Boolean; encoding : TEncoding);
 begin
   inherited Create();
   fIssues := TStringList.Create();
 
   fOutput := outputStream;
-  fOwnOut := ownsStream
+  fOwnOut := ownsStream;
+
+  if encoding <> nil then
+    fEncoding := encoding
+  else
+    fEncoding := TEncoding.UTF8;
 end;
 
 procedure TDunitXTextLogger.DecIndent(const Steps : Integer);
@@ -346,7 +352,7 @@ begin
   else
     bufS := sLineBreak;
   {-}
-  bufB := TEncoding.UTF8.GetBytes(bufS);
+  bufB := fEncoding.GetBytes(bufS);
   fOutput.Write(bufB, Length(bufB))
 end;
 
@@ -394,7 +400,7 @@ begin
     outStream.Seek(0, soFromEnd)
   end;
 
-  inherited Create(outStream, True)
+  inherited Create(outStream, True, outEncoding)
 end;
 
 {$ENDREGION 'TDunitXTextFileLogger'}

--- a/Source/DUnitX.Loggers.Text.pas
+++ b/Source/DUnitX.Loggers.Text.pas
@@ -247,6 +247,7 @@ begin
     WriteLine('- Memory Leaks:  %d', [RunResults.MemoryLeakCount]);
   if RunResults.AllPassed then
     WriteLine('- All PASSED');
+  WriteLine()
 end;
 
 procedure TDunitXTextLogger.OnTestingStarts(const threadId : TThreadID; testCount, testActiveCount : Cardinal);
@@ -375,27 +376,40 @@ var
   outStream : TOutputStream;
   outEncoding : TEncoding;
   bufBOM : TBytes;
+  len : Integer;
 
 begin
   outName := FileName;
   if outName = '' then
     outName := ChangeFileExt(ParamStr(0), '.log');
 
-  outEncoding := encoding;
-  if outEncoding = nil then
-    outEncoding := TEncoding.UTF8;
-
-  if overwrite then
+  if overwrite or not FileExists(outName) then
   begin
     outStream := TOutputStream.Create(outName, fmCreate);
 
+    if encoding <> nil then
+      outEncoding := encoding
+    else
+      outEncoding := TEncoding.UTF8;
+
     bufBOM := outEncoding.GetPreamble();
-    //todo : confirm this work
-    outStream.Write(bufBOM, Length(bufBOM))
+    if bufBOM <> nil then
+      outStream.Write(bufBOM, Length(bufBOM))
   end
   else
   begin
     outStream := TOutputStream.Create(outName, fmOpenReadWrite);
+
+    outEncoding := encoding;
+    if outEncoding = nil then
+    begin
+      // A standard BOM consists of 2 to 4 bytes.
+      // In the case of exotic encodings, such as UTF-7, the BOM may consist of 5 bytes.
+      SetLength(bufBOM, 5);
+      len := outStream.Read(bufBOM, 5);
+      SetLength(bufBOM, len);
+      TEncoding.GetBufferEncoding(bufBOM, outEncoding, TEncoding.UTF8)
+    end;
 
     outStream.Seek(0, soFromEnd)
   end;


### PR DESCRIPTION
Inspired by your comment in source code, I started checking the text encoding. As a result, I discovered a bug whereby UTF-8 encoding had been hard-coded into the code, rather than using the encoding specified in the constructor.

I also discovered that if the `overwrite` parameter is set to `false` and the log file does not exist, attempting to open the file results in an exception being thrown.

Since I’d already started analysing this code, I implemented an improvement. If the `encoding` parameter is `nil` and the file exists, I try to retrieve the encoding from the existing log,