### PR TITLE
FMX pseudo-console for Android / iOS

### DIFF
--- a/Docs/FMX-Pseudo-Console.md
+++ b/Docs/FMX-Pseudo-Console.md
@@ -37,7 +37,8 @@ FMX designer/form files break across Delphi versions. Related history:
 ## Example
 
 `Examples/DUnitXConsoleFMX.dpr` - one modern FMX multi-device example
-(Win32 + Android). Not a version matrix. Include path points at `Source`.
+(Win32, Win64, Android, iOSDevice64, iOSSimARM64). Not a version matrix.
+Include path points at `Source`.
 
 ## Usage
 

--- a/Docs/FMX-Pseudo-Console.md
+++ b/Docs/FMX-Pseudo-Console.md
@@ -1,0 +1,53 @@
+# FMX Pseudo-Console
+
+## Purpose
+
+Android and iOS have no console applications (Embarcadero still has no mobile
+console; Quality Portal RSP-17631). This branch adds a **console stand-in** so
+the same DUnitX suite can run on a device and show console-style output.
+
+This is **not** a GUI test explorer. TestInsight remains the IDE path.
+MobileGUI / GUIX / VCL GUI are left alone.
+
+## Shape (intentionally tiny)
+
+1. `TDUnitXFMXConsoleLogger` (`Source/DUnitX.Loggers.Console.FMX.pas`) -
+   an `ITestLogger` that appends console-style lines to a `TStrings` (typically
+   a `TMemo.Lines`). Message text mirrors `TDUnitXConsoleLogger` (quiet/verbose).
+   It never calls `Write`/`WriteLn` or `TDUnitXConsoleLogger`.
+2. `TDUnitXFMXConsoleHost` + `Run` in the same unit - a form built entirely with
+   `TForm.CreateNew` + `TMemo` + status `TLabel` (+ optional "Run again").
+   Auto-runs the registered suite on first show.
+
+## Why there is no `.fmx`
+
+FMX designer/form files break across Delphi versions. Related history:
+
+| Issue | Note |
+|-------|------|
+| #19, #39, #153 | FMX GUI was a contribution; never really finished. Vincent will not maintain FMX. |
+| #154 | VCL GUI wiring uses `{$IFNDEF GUI}{$IFNDEF TESTINSIGHT}{$APPTYPE CONSOLE}` and `DUnitX.Loggers.GUI.VCL.Run`. |
+| #217 | "Run on android" (closed): console apps unsupported on Android. |
+| #172 | NUnit file logger + Android path/`TMonitor` issues. Optional XML (not in this change) should use documents path. |
+| #230 | Tokyo FMX GUI example crashes; still broken in 10.4+. Do not extend those example projects. |
+| #327 | Repro already uses `TForm` + `TMemo` and dumps results after the run - the UX we want, as a live `ITestLogger`. |
+| #214 / #324 | I/O 105 when writing to a console that is not a console app. |
+| #383 | Vincent: happy to take PRs; support many Delphi versions; avoid IDE-edited `.fmx` files. |
+
+## Example
+
+`Examples/DUnitXConsoleFMX.dpr` - one modern FMX multi-device example
+(Win32 + Android). Not a version matrix. Include path points at `Source`.
+
+## Usage
+
+```delphi
+uses
+  DUnitX.Loggers.Console.FMX;
+
+begin
+  DUnitX.Loggers.Console.FMX.Run;
+end.
+```
+
+Or host your own memo and attach `TDUnitXFMXConsoleLogger.Create(Memo.Lines)`.

--- a/Examples/DUnitX.Examples.Console.FMX.pas
+++ b/Examples/DUnitX.Examples.Console.FMX.pas
@@ -1,0 +1,70 @@
+﻿{***************************************************************************}
+{                                                                           }
+{           DUnitX                                                          }
+{                                                                           }
+{           Copyright (C) 2015 Vincent Parrett & Contributors               }
+{                                                                           }
+{           vincent@finalbuilder.com                                        }
+{           http://www.finalbuilder.com                                     }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Licensed under the Apache License, Version 2.0 (the "License");          }
+{  you may not use this file except in compliance with the License.         }
+{  You may obtain a copy of the License at                                  }
+{                                                                           }
+{      http://www.apache.org/licenses/LICENSE-2.0                           }
+{                                                                           }
+{  Unless required by applicable law or agreed to in writing, software      }
+{  distributed under the License is distributed on an "AS IS" BASIS,        }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. }
+{  See the License for the specific language governing permissions and      }
+{  limitations under the License.                                           }
+{                                                                           }
+{***************************************************************************}
+
+unit DUnitX.Examples.Console.FMX;
+
+interface
+
+{$I DUnitX.inc}
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture('Examples.Console.FMX', 'Tiny sample for the FMX pseudo-console')]
+  TConsoleFMXExampleTests = class
+  public
+    [Test]
+    procedure PassingAssertion;
+
+    [Test]
+    procedure AnotherPassingAssertion;
+
+    [Test]
+    [Ignore('Shows ignored output in the pseudo-console')]
+    procedure IgnoredSample;
+  end;
+
+implementation
+
+procedure TConsoleFMXExampleTests.PassingAssertion;
+begin
+  Assert.AreEqual(4, 2 + 2);
+end;
+
+procedure TConsoleFMXExampleTests.AnotherPassingAssertion;
+begin
+  Assert.IsTrue(True, 'FMX pseudo-console logger is alive');
+end;
+
+procedure TConsoleFMXExampleTests.IgnoredSample;
+begin
+  Assert.IsTrue(False, 'Should never run');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TConsoleFMXExampleTests);
+
+end.

--- a/Examples/DUnitXConsoleFMX.dpr
+++ b/Examples/DUnitXConsoleFMX.dpr
@@ -1,6 +1,6 @@
 ﻿program DUnitXConsoleFMX;
 
-{
+(*
   FMX pseudo-console example for DUnitX.
 
   This is an FMX application - not {$APPTYPE CONSOLE}.
@@ -9,7 +9,7 @@
   output in a code-created memo host.
 
   See Docs/FMX-Pseudo-Console.md and Source/DUnitX.Loggers.Console.FMX.pas.
-}
+*)
 
 uses
   System.StartUpCopy,

--- a/Examples/DUnitXConsoleFMX.dpr
+++ b/Examples/DUnitXConsoleFMX.dpr
@@ -1,0 +1,23 @@
+﻿program DUnitXConsoleFMX;
+
+{
+  FMX pseudo-console example for DUnitX.
+
+  This is an FMX application - not {$APPTYPE CONSOLE}.
+  Define nothing special for console mode. Android/iOS (and any FMX target
+  without a real console) can run the same suite and see console-style
+  output in a code-created memo host.
+
+  See Docs/FMX-Pseudo-Console.md and Source/DUnitX.Loggers.Console.FMX.pas.
+}
+
+uses
+  System.StartUpCopy,
+  FMX.Forms,
+  DUnitX.Loggers.Console.FMX in '..\Source\DUnitX.Loggers.Console.FMX.pas',
+  DUnitX.Examples.Console.FMX in 'DUnitX.Examples.Console.FMX.pas';
+
+
+begin
+  DUnitX.Loggers.Console.FMX.Run;
+end.

--- a/Examples/DUnitXConsoleFMX.dproj
+++ b/Examples/DUnitXConsoleFMX.dproj
@@ -1,0 +1,140 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{888E55C8-4E5B-4620-B3CE-5B4298B755B5}</ProjectGuid>
+        <ProjectVersion>19.2</ProjectVersion>
+        <FrameworkType>FMX</FrameworkType>
+        <MainSource>DUnitXConsoleFMX.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>17</TargetedPlatforms>
+        <AppType>Application</AppType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
+        <Base_Android>true</Base_Android>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <SanitizedProjectName>DUnitXConsoleFMX</SanitizedProjectName>
+        <DCC_UnitSearchPath>..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android)'!=''">
+        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=</VerInfo_Keys>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
+        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
+        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
+        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
+        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
+        <EnabledSysJExt>true</EnabledSysJExt>
+        <AUP_ACCESS_COARSE_LOCATION>false</AUP_ACCESS_COARSE_LOCATION>
+        <AUP_ACCESS_FINE_LOCATION>false</AUP_ACCESS_FINE_LOCATION>
+        <AUP_CALL_PHONE>false</AUP_CALL_PHONE>
+        <AUP_CAMERA>false</AUP_CAMERA>
+        <AUP_INTERNET>false</AUP_INTERNET>
+        <AUP_READ_CALENDAR>false</AUP_READ_CALENDAR>
+        <AUP_READ_EXTERNAL_STORAGE>false</AUP_READ_EXTERNAL_STORAGE>
+        <AUP_WRITE_CALENDAR>false</AUP_WRITE_CALENDAR>
+        <AUP_WRITE_EXTERNAL_STORAGE>false</AUP_WRITE_EXTERNAL_STORAGE>
+        <AUP_READ_PHONE_STATE>false</AUP_READ_PHONE_STATE>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="..\Source\DUnitX.Loggers.Console.FMX.pas"/>
+        <DCCReference Include="DUnitX.Examples.Console.FMX.pas"/>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">DUnitXConsoleFMX.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Android">True</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/Examples/DUnitXConsoleFMX.dproj
+++ b/Examples/DUnitXConsoleFMX.dproj
@@ -162,7 +162,7 @@
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
         <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
-        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Define>DEBUG;DUNITXDEBUG;$(DCC_Define)</DCC_Define>
         <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
         <DCC_Optimize>false</DCC_Optimize>
     </PropertyGroup>

--- a/Examples/DUnitXConsoleFMX.dproj
+++ b/Examples/DUnitXConsoleFMX.dproj
@@ -7,7 +7,7 @@
         <Base>True</Base>
         <Config Condition="'$(Config)'==''">Debug</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
-        <TargetedPlatforms>17</TargetedPlatforms>
+        <TargetedPlatforms>4167</TargetedPlatforms>
         <AppType>Application</AppType>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -15,6 +15,16 @@
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
         <Base_Android>true</Base_Android>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Base)'=='true') or '$(Base_iOSSimARM64)'!=''">
+        <Base_iOSSimARM64>true</Base_iOSSimARM64>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
@@ -73,6 +83,19 @@
         <AUP_WRITE_EXTERNAL_STORAGE>false</AUP_WRITE_EXTERNAL_STORAGE>
         <AUP_READ_PHONE_STATE>false</AUP_READ_PHONE_STATE>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimARM64)'!=''">
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
@@ -129,6 +152,8 @@
             </Delphi.Personality>
             <Platforms>
                 <Platform value="Android">True</Platform>
+                <Platform value="iOSDevice64">True</Platform>
+                <Platform value="iOSSimARM64">True</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
             </Platforms>

--- a/Examples/DUnitXConsoleFMX.dproj
+++ b/Examples/DUnitXConsoleFMX.dproj
@@ -1,30 +1,21 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <ProjectGuid>{888E55C8-4E5B-4620-B3CE-5B4298B755B5}</ProjectGuid>
-        <ProjectVersion>19.2</ProjectVersion>
+        <Base>True</Base>
+        <AppType>Application</AppType>
+        <Config Condition="'$(Config)'==''">Debug</Config>
         <FrameworkType>FMX</FrameworkType>
         <MainSource>DUnitXConsoleFMX.dpr</MainSource>
-        <Base>True</Base>
-        <Config Condition="'$(Config)'==''">Debug</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
-        <TargetedPlatforms>4167</TargetedPlatforms>
-        <AppType>Application</AppType>
+        <ProjectGuid>{888E55C8-4E5B-4620-B3CE-5B4298B755B5}</ProjectGuid>
+        <ProjectName Condition="'$(ProjectName)'==''">DUnitXConsoleFMX</ProjectName>
+        <ProjectVersion>20.4</ProjectVersion>
+        <TargetedPlatforms>525331</TargetedPlatforms>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
         <Base_Android>true</Base_Android>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
-        <Base_iOSDevice64>true</Base_iOSDevice64>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Base)'=='true') or '$(Base_iOSSimARM64)'!=''">
-        <Base_iOSSimARM64>true</Base_iOSSimARM64>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
@@ -38,9 +29,43 @@
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Base)'=='true') or '$(Base_iOSSimARM64)'!=''">
+        <Base_iOSSimARM64>true</Base_iOSSimARM64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
         <Cfg_1>true</Cfg_1>
         <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Cfg_1)'=='true') or '$(Cfg_1_Android)'!=''">
+        <Cfg_1_Android>true</Cfg_1_Android>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win64)'!=''">
+        <Cfg_1_Win64>true</Cfg_1_Win64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimARM64' and '$(Cfg_1)'=='true') or '$(Cfg_1_iOSSimARM64)'!=''">
+        <Cfg_1_iOSSimARM64>true</Cfg_1_iOSSimARM64>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
         <Base>true</Base>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
@@ -50,28 +75,23 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
         <SanitizedProjectName>DUnitXConsoleFMX</SanitizedProjectName>
-        <DCC_UnitSearchPath>..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
-        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <AUP_ACCESS_COARSE_LOCATION>true</AUP_ACCESS_COARSE_LOCATION>
+        <AUP_ACCESS_FINE_LOCATION>true</AUP_ACCESS_FINE_LOCATION>
+        <AUP_CALL_PHONE>true</AUP_CALL_PHONE>
+        <AUP_CAMERA>true</AUP_CAMERA>
+        <AUP_INTERNET>true</AUP_INTERNET>
+        <AUP_READ_EXTERNAL_STORAGE>true</AUP_READ_EXTERNAL_STORAGE>
+        <AUP_READ_PHONE_STATE>true</AUP_READ_PHONE_STATE>
+        <AUP_WRITE_EXTERNAL_STORAGE>true</AUP_WRITE_EXTERNAL_STORAGE>
         <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
-        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitSearchPath>..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
-        <DCC_E>false</DCC_E>
-        <DCC_N>false</DCC_N>
-        <DCC_S>false</DCC_S>
-        <DCC_F>false</DCC_F>
-        <DCC_K>false</DCC_K>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android)'!=''">
-        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=</VerInfo_Keys>
-        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
-        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
-        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
-        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
-        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
-        <EnabledSysJExt>true</EnabledSysJExt>
         <AUP_ACCESS_COARSE_LOCATION>false</AUP_ACCESS_COARSE_LOCATION>
         <AUP_ACCESS_FINE_LOCATION>false</AUP_ACCESS_FINE_LOCATION>
         <AUP_CALL_PHONE>false</AUP_CALL_PHONE>
@@ -79,30 +99,26 @@
         <AUP_INTERNET>false</AUP_INTERNET>
         <AUP_READ_CALENDAR>false</AUP_READ_CALENDAR>
         <AUP_READ_EXTERNAL_STORAGE>false</AUP_READ_EXTERNAL_STORAGE>
+        <AUP_READ_PHONE_STATE>false</AUP_READ_PHONE_STATE>
         <AUP_WRITE_CALENDAR>false</AUP_WRITE_CALENDAR>
         <AUP_WRITE_EXTERNAL_STORAGE>false</AUP_WRITE_EXTERNAL_STORAGE>
-        <AUP_READ_PHONE_STATE>false</AUP_READ_PHONE_STATE>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
+        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
+        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
+        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
+        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
+        <EnabledSysJExt>true</EnabledSysJExt>
+        <EnabledSysJars>activity-1.7.2.dex.jar;annotation-experimental-1.4.1.dex.jar;annotation-jvm-1.8.1.dex.jar;annotations-23.0.0.dex.jar;appcompat-1.2.0.dex.jar;appcompat-resources-1.2.0.dex.jar;billing-7.1.1.dex.jar;biometric-1.1.0.dex.jar;browser-1.4.0.dex.jar;cloud-messaging.dex.jar;collection-jvm-1.4.2.dex.jar;concurrent-futures-1.1.0.dex.jar;core-1.17.0.dex.jar;core-common-2.2.0.dex.jar;core-ktx-1.17.0.dex.jar;core-runtime-2.2.0.dex.jar;core-viewtree-1.0.0.dex.jar;cursoradapter-1.0.0.dex.jar;customview-1.0.0.dex.jar;documentfile-1.0.0.dex.jar;drawerlayout-1.0.0.dex.jar;error_prone_annotations-2.9.0.dex.jar;exifinterface-1.3.6.dex.jar;firebase-annotations-16.2.0.dex.jar;firebase-common-20.3.1.dex.jar;firebase-components-17.1.0.dex.jar;firebase-datatransport-18.1.7.dex.jar;firebase-encoders-17.0.0.dex.jar;firebase-encoders-json-18.0.0.dex.jar;firebase-encoders-proto-16.0.0.dex.jar;firebase-iid-interop-17.1.0.dex.jar;firebase-installations-17.1.3.dex.jar;firebase-installations-interop-17.1.0.dex.jar;firebase-measurement-connector-19.0.0.dex.jar;firebase-messaging-23.1.2.dex.jar;fmx.dex.jar;fragment-1.2.5.dex.jar;google-play-licensing.dex.jar;interpolator-1.0.0.dex.jar;javax.inject-1.dex.jar;jspecify-1.0.0.dex.jar;kotlin-stdlib-2.1.21.dex.jar;kotlinx-coroutines-android-1.8.1.dex.jar;kotlinx-coroutines-core-jvm-1.8.1.dex.jar;legacy-support-core-utils-1.0.0.dex.jar;lifecycle-common-2.6.2.dex.jar;lifecycle-livedata-2.6.2.dex.jar;lifecycle-livedata-core-2.6.2.dex.jar;lifecycle-runtime-2.6.2.dex.jar;lifecycle-service-2.6.2.dex.jar;lifecycle-viewmodel-2.6.2.dex.jar;lifecycle-viewmodel-savedstate-2.6.2.dex.jar;listenablefuture-1.0.dex.jar;loader-1.0.0.dex.jar;localbroadcastmanager-1.0.0.dex.jar;okio-jvm-3.4.0.dex.jar;play-services-ads-22.2.0.dex.jar;play-services-ads-base-22.2.0.dex.jar;play-services-ads-identifier-18.0.0.dex.jar;play-services-ads-lite-22.2.0.dex.jar;play-services-appset-16.0.1.dex.jar;play-services-base-18.5.0.dex.jar;play-services-basement-18.4.0.dex.jar;play-services-cloud-messaging-17.0.1.dex.jar;play-services-location-21.0.1.dex.jar;play-services-maps-18.1.0.dex.jar;play-services-measurement-base-20.1.2.dex.jar;play-services-measurement-sdk-api-20.1.2.dex.jar;play-services-stats-17.0.2.dex.jar;play-services-tasks-18.2.0.dex.jar;print-1.0.0.dex.jar;profileinstaller-1.3.0.dex.jar;room-common-2.2.5.dex.jar;room-runtime-2.2.5.dex.jar;savedstate-1.2.1.dex.jar;sqlite-2.1.0.dex.jar;sqlite-framework-2.1.0.dex.jar;startup-runtime-1.1.1.dex.jar;tracing-1.2.0.dex.jar;transport-api-3.0.0.dex.jar;transport-backend-cct-3.1.8.dex.jar;transport-runtime-3.1.8.dex.jar;user-messaging-platform-2.0.0.dex.jar;vectordrawable-1.1.0.dex.jar;vectordrawable-animated-1.1.0.dex.jar;versionedparcelable-1.1.1.dex.jar;viewpager-1.0.0.dex.jar;work-runtime-2.7.0.dex.jar</EnabledSysJars>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
-        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
-        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
-        <BT_BuildType>Debug</BT_BuildType>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_iOSSimARM64)'!=''">
-        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
-        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
-        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
+        <VerInfo_Keys>package=com.embarcadero.$(MSBuildProjectName);label=$(MSBuildProjectName);versionCode=1;versionName=1.0.0;persistent=False;restoreAnyVersion=False;installLocation=auto;largeHeap=False;theme=TitleBar;hardwareAccelerated=true;apiKey=;minSdkVersion=23;targetSdkVersion=36</VerInfo_Keys>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
+        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
-        <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
-        <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
@@ -110,18 +126,63 @@
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <VerInfo_Locale>1033</VerInfo_Locale>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimARM64)'!=''">
+        <VerInfo_BundleId>$(MSBuildProjectName)</VerInfo_BundleId>
+        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
+        <VerInfo_Keys>CFBundleName=$(MSBuildProjectName);CFBundleDisplayName=$(MSBuildProjectName);CFBundleIdentifier=$(MSBuildProjectName);CFBundleVersion=1.0.0;CFBundleShortVersionString=1.0.0;CFBundlePackageType=APPL;CFBundleSignature=????;CFBundleAllowMixedLocalizations=YES;CFBundleExecutable=$(MSBuildProjectName);LSRequiresIPhoneOS=true;UIDeviceFamily=iPhone &amp; iPad;ITSAppUsesNonExemptEncryption=false</VerInfo_Keys>
+        <VerInfo_UIDeviceFamily>iPhoneAndiPad</VerInfo_UIDeviceFamily>
+        <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
+        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
+        <iPad_AppIcon167>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_167x167.png</iPad_AppIcon167>
+        <iPad_Launch2x>$(BDS)\bin\Artwork\iOS\iPad\FM_LaunchImage_2x.png</iPad_Launch2x>
+        <iPad_LaunchDark2x>$(BDS)\bin\Artwork\iOS\iPad\FM_LaunchImageDark_2x.png</iPad_LaunchDark2x>
+        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
+        <iPad_Setting58>$(BDS)\bin\Artwork\iOS\iPad\FM_SettingIcon_58x58.png</iPad_Setting58>
+        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
+        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
+        <iPhone_AppIcon180>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_180x180.png</iPhone_AppIcon180>
+        <iPhone_Launch2x>$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImage_2x.png</iPhone_Launch2x>
+        <iPhone_Launch3x>$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImage_3x.png</iPhone_Launch3x>
+        <iPhone_LaunchDark2x>$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImageDark_2x.png</iPhone_LaunchDark2x>
+        <iPhone_LaunchDark3x>$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImageDark_3x.png</iPhone_LaunchDark3x>
+        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
+        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
+        <iPhone_Setting58>$(BDS)\bin\Artwork\iOS\iPhone\FM_SettingIcon_58x58.png</iPhone_Setting58>
+        <iPhone_Setting87>$(BDS)\bin\Artwork\iOS\iPhone\FM_SettingIcon_87x87.png</iPhone_Setting87>
+        <iPhone_Spotlight120>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_120x120.png</iPhone_Spotlight120>
+        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
-        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
         <DCC_DebugDCUs>true</DCC_DebugDCUs>
-        <DCC_Optimize>false</DCC_Optimize>
-        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
         <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_Optimize>false</DCC_Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Android)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
+        <BT_BuildType>Debug</BT_BuildType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_iOSSimARM64)'!=''">
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
-        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
-        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
-        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
         <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">
@@ -129,12 +190,12 @@
         </DelphiCompile>
         <DCCReference Include="..\Source\DUnitX.Loggers.Console.FMX.pas"/>
         <DCCReference Include="DUnitX.Examples.Console.FMX.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_1</Key>
             <CfgParent>Base</CfgParent>
-        </BuildConfiguration>
-        <BuildConfiguration Include="Base">
-            <Key>Base</Key>
         </BuildConfiguration>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
@@ -152,10 +213,13 @@
             </Delphi.Personality>
             <Platforms>
                 <Platform value="Android">True</Platform>
-                <Platform value="iOSDevice64">True</Platform>
-                <Platform value="iOSSimARM64">True</Platform>
+                <Platform value="Android64">False</Platform>
+                <Platform value="OSX64">False</Platform>
+                <Platform value="OSXARM64">False</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
+                <Platform value="iOSDevice64">True</Platform>
+                <Platform value="iOSSimARM64">True</Platform>
             </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is far from a complete list, but a few planned features are listed here to 
 
 Tips and Tricks
 ===========
+* FMX / mobile: there is no console app on Android/iOS. Use `DUnitX.Loggers.Console.FMX` (`DUnitX.Loggers.Console.FMX.Run`) as a console stand-in that streams results to an in-app memo. This is **not** a GUI test explorer; for IDE workflows use [TestInsight](https://bitbucket.org/sglienke/testinsight/wiki/Home). See [Docs/FMX-Pseudo-Console.md](Docs/FMX-Pseudo-Console.md).
 * In order to workaround the [Delphi XE3 Bug](https://github.com/VSoftTechnologies/DUnitX/issues/117), you need to add the unit DUnitX.Init to your test projects.
 * To use this GitHub version of DUnitX in place of the bundled version included with RAD Studio, it’s pretty simple by following these steps (as the bundled version is quite a few commits behind this repo):
   - Remove the Embarcadero Unit test package (DUnitXIDEExpertXXX.bpl) from the installed packages list.

--- a/Source/DUnitX.Loggers.Console.FMX.pas
+++ b/Source/DUnitX.Loggers.Console.FMX.pas
@@ -1,0 +1,536 @@
+﻿{***************************************************************************}
+{                                                                           }
+{           DUnitX                                                          }
+{                                                                           }
+{           Copyright (C) 2015 Vincent Parrett & Contributors               }
+{                                                                           }
+{           vincent@finalbuilder.com                                        }
+{           http://www.finalbuilder.com                                     }
+{                                                                           }
+{***************************************************************************}
+{                                                                           }
+{  Licensed under the Apache License, Version 2.0 (the "License");          }
+{  you may not use this file except in compliance with the License.         }
+{  You may obtain a copy of the License at                                  }
+{                                                                           }
+{      http://www.apache.org/licenses/LICENSE-2.0                           }
+{                                                                           }
+{  Unless required by applicable law or agreed to in writing, software      }
+{  distributed under the License is distributed on an "AS IS" BASIS,        }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. }
+{  See the License for the specific language governing permissions and      }
+{  limitations under the License.                                           }
+{                                                                           }
+{***************************************************************************}
+
+unit DUnitX.Loggers.Console.FMX;
+
+interface
+
+{$I DUnitX.inc}
+
+uses
+{$IFDEF USE_NS}
+  System.Classes,
+  System.SysUtils,
+  FMX.Types,
+  FMX.Controls,
+  FMX.Forms,
+  FMX.StdCtrls,
+  FMX.Memo,
+  FMX.Controls.Presentation,
+{$ELSE}
+  Classes,
+  SysUtils,
+  FMX.Types,
+  FMX.Controls,
+  FMX.Forms,
+  FMX.StdCtrls,
+  FMX.Memo,
+{$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.ResStrs;
+
+type
+  /// <summary>
+  ///   Console-style ITestLogger that appends lines to a TStrings (typically a TMemo.Lines).
+  ///   Mirrors TDUnitXConsoleLogger message text. Never writes to a real console.
+  /// </summary>
+  TDUnitXFMXConsoleLogger = class(TInterfacedObject, ITestLogger)
+  private
+    FLines : TStrings;
+    FQuietMode : boolean;
+    FIndent : Integer;
+    FPendingLine : string;
+    FHasPending : boolean;
+    procedure Indent(const value : Integer = 1);
+    procedure Outdent(const value : Integer = 1);
+    procedure Write(const s : string);
+    procedure WriteLn; overload;
+    procedure WriteLn(const s : string); overload;
+  protected
+    procedure OnTestingStarts(const threadId : TThreadID; testCount, testActiveCount : Cardinal);
+    procedure OnStartTestFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+    procedure OnSetupFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+    procedure OnEndSetupFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+    procedure OnBeginTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnSetupTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnEndSetupTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnExecuteTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnTestMemoryLeak(const threadId : TThreadID; const Test : ITestResult);
+    procedure OnTestIgnored(const threadId : TThreadID; const AIgnored : ITestResult);
+    procedure OnTestError(const threadId : TThreadID; const Error : ITestError);
+    procedure OnTestFailure(const threadId : TThreadID; const Failure : ITestError);
+    procedure OnTestSuccess(const threadId : TThreadID; const Test : ITestResult);
+    procedure OnLog(const logType : TLogLevel; const msg : string);
+    procedure OnTeardownTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnEndTeardownTest(const threadId : TThreadID; const Test : ITestInfo);
+    procedure OnEndTest(const threadId : TThreadID; const Test : ITestResult);
+    procedure OnTearDownFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+    procedure OnEndTearDownFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+    procedure OnEndTestFixture(const threadId : TThreadID; const results : IFixtureResult);
+    procedure OnTestingEnds(const RunResults : IRunResults);
+  public
+    constructor Create(const ALines : TStrings; const quietMode : boolean = False);
+  end;
+
+  /// <summary>
+  ///   Code-created FMX host (no .fmx). Memo + status label; auto-runs the suite on first show.
+  /// </summary>
+  TDUnitXFMXConsoleHost = class(TForm)
+  private
+    FStatus : TLabel;
+    FRunAgain : TButton;
+    FMemo : TMemo;
+    FHasAutoRun : Boolean;
+    FRunning : Boolean;
+    procedure BuildUI;
+    procedure HandleShow(Sender : TObject);
+    procedure HandleRunAgainClick(Sender : TObject);
+    procedure RunTests;
+  public
+    constructor CreateNew(AOwner : TComponent; Dummy : NativeInt = 0); override;
+  end;
+
+/// <summary>
+///   FMX entry point analogous to DUnitX.Loggers.GUI.VCL.Run.
+///   Creates a code-built host form and runs the registered suite.
+/// </summary>
+procedure Run;
+
+implementation
+
+{ TDUnitXFMXConsoleLogger }
+
+constructor TDUnitXFMXConsoleLogger.Create(const ALines : TStrings; const quietMode : boolean);
+begin
+  inherited Create;
+  if ALines = nil then
+    raise Exception.Create('ALines must not be nil');
+  FLines := ALines;
+  FQuietMode := quietMode;
+  FIndent := 0;
+  FHasPending := False;
+end;
+
+procedure TDUnitXFMXConsoleLogger.Indent(const value : Integer);
+begin
+  Inc(FIndent, value);
+  if FIndent < 0 then
+    FIndent := 0;
+end;
+
+procedure TDUnitXFMXConsoleLogger.Outdent(const value : Integer);
+begin
+  Dec(FIndent, value);
+  if FIndent < 0 then
+    FIndent := 0;
+end;
+
+procedure TDUnitXFMXConsoleLogger.Write(const s : string);
+begin
+  if not FHasPending then
+  begin
+    FPendingLine := StringOfChar(' ', FIndent) + s;
+    FHasPending := True;
+  end
+  else
+    FPendingLine := FPendingLine + s;
+end;
+
+procedure TDUnitXFMXConsoleLogger.WriteLn;
+begin
+  WriteLn('');
+end;
+
+procedure TDUnitXFMXConsoleLogger.WriteLn(const s : string);
+begin
+  if FHasPending then
+  begin
+    FLines.Add(FPendingLine + s);
+    FPendingLine := '';
+    FHasPending := False;
+  end
+  else
+    FLines.Add(StringOfChar(' ', FIndent) + s);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestingStarts(const threadId : TThreadID; testCount, testActiveCount : Cardinal);
+begin
+  if FQuietMode then
+  begin
+    WriteLn(Format(SStartingTests, [ExtractFileName(ParamStr(0))]));
+    WriteLn;
+  end;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnStartTestFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  Indent(2);
+  WriteLn(SFixture + fixture.FullName);
+  WriteLn('-------------------------------------------------');
+  Indent(1);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnSetupFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  Indent(1);
+  WriteLn(SRunningFixtureSetup + fixture.SetupFixtureMethodName);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndSetupFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  Outdent(1);
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnBeginTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  Indent(1);
+  WriteLn(STest + Test.FullName);
+  WriteLn('-------------------------------------------------');
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnSetupTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  WriteLn(SRunningSetup + Test.Name);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndSetupTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnExecuteTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+  if FQuietMode then
+  begin
+    Write('.');
+    Exit;
+  end;
+
+  WriteLn(SExecutingTest + Test.Name);
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestError(const threadId : TThreadID; const Error : ITestError);
+begin
+  if FQuietMode then
+    Write('E');
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestFailure(const threadId : TThreadID; const Failure : ITestError);
+begin
+  if FQuietMode then
+    Write('F');
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestIgnored(const threadId : TThreadID; const AIgnored : ITestResult);
+begin
+  if FQuietMode then
+    Write('I');
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestMemoryLeak(const threadId : TThreadID; const Test : ITestResult);
+begin
+  if FQuietMode then
+    Write('M');
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestSuccess(const threadId : TThreadID; const Test : ITestResult);
+var
+  sMessage : string;
+begin
+  if FQuietMode then
+  begin
+    Write('.');
+    Exit;
+  end;
+
+  Indent(2);
+  if Test.Message <> '' then
+    sMessage := SSuccess + ' : ' + Test.Message
+  else
+    sMessage := SSuccess + '.';
+  WriteLn(sMessage);
+  Outdent(2);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnLog(const logType : TLogLevel; const msg : string);
+begin
+  if FQuietMode then
+    Exit;
+
+  Indent(2);
+  try
+    WriteLn(msg);
+  finally
+    Outdent(2);
+  end;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTeardownTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  WriteLn;
+  Indent(1);
+  WriteLn(SRunningTestTeardown + Test.Name);
+  WriteLn;
+  Outdent(1);
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndTeardownTest(const threadId : TThreadID; const Test : ITestInfo);
+begin
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndTest(const threadId : TThreadID; const Test : ITestResult);
+begin
+  if FQuietMode then
+    Exit;
+
+  Outdent(1);
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTearDownFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+begin
+  if FQuietMode then
+    Exit;
+
+  WriteLn(SRunningFixtureTeardown + fixture.TearDownFixtureMethodName);
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndTearDownFixture(const threadId : TThreadID; const fixture : ITestFixtureInfo);
+begin
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnEndTestFixture(const threadId : TThreadID; const results : IFixtureResult);
+begin
+  if FQuietMode then
+    Exit;
+
+  Outdent(3);
+  WriteLn;
+end;
+
+procedure TDUnitXFMXConsoleLogger.OnTestingEnds(const RunResults : IRunResults);
+var
+  testResult : ITestResult;
+begin
+  if FQuietMode then
+  begin
+    WriteLn;
+    WriteLn;
+  end
+  else
+  begin
+    Outdent(1);
+    WriteLn(SDoneTesting);
+  end;
+
+  WriteLn(Format(STestsFound, [RunResults.TestCount]));
+  WriteLn(Format(STestsIgnored, [RunResults.IgnoredCount]));
+  WriteLn(Format(STestsPassed, [RunResults.PassCount]));
+  WriteLn(Format(STestsLeaked, [RunResults.MemoryLeakCount]));
+  WriteLn(Format(STestsFailed, [RunResults.FailureCount]));
+  WriteLn(Format(STestsErrored, [RunResults.ErrorCount]));
+
+  if RunResults.FailureCount > 0 then
+  begin
+    WriteLn;
+    WriteLn(SFailingTests);
+    WriteLn;
+    for testResult in RunResults.GetAllTestResults do
+    begin
+      if testResult.ResultType = TTestResultType.Failure then
+      begin
+        WriteLn('  ' + testResult.Test.FullName);
+        WriteLn(SMessage + testResult.Message);
+        WriteLn;
+      end;
+    end;
+    WriteLn;
+  end;
+
+  if RunResults.ErrorCount > 0 then
+  begin
+    WriteLn;
+    WriteLn(STestsWithErrors);
+    WriteLn;
+    for testResult in RunResults.GetAllTestResults do
+    begin
+      if testResult.ResultType = TTestResultType.Error then
+      begin
+        WriteLn('  ' + testResult.Test.FullName);
+        WriteLn(SMessage + testResult.Message);
+        WriteLn;
+      end;
+    end;
+    WriteLn;
+  end;
+
+  if RunResults.MemoryLeakCount > 0 then
+  begin
+    WriteLn;
+    WriteLn(STestsWithLeak);
+    WriteLn;
+    for testResult in RunResults.GetAllTestResults do
+    begin
+      if testResult.ResultType = TTestResultType.MemoryLeak then
+      begin
+        WriteLn('  ' + testResult.Test.FullName);
+        WriteLn(SMessage + testResult.Message);
+        WriteLn;
+      end;
+    end;
+    WriteLn;
+  end;
+end;
+
+{ TDUnitXFMXConsoleHost }
+
+constructor TDUnitXFMXConsoleHost.CreateNew(AOwner : TComponent; Dummy : NativeInt);
+begin
+  inherited CreateNew(AOwner, Dummy);
+  Caption := 'DUnitX';
+  Width := 700;
+  Height := 500;
+  FHasAutoRun := False;
+  FRunning := False;
+  BuildUI;
+  OnShow := HandleShow;
+end;
+
+procedure TDUnitXFMXConsoleHost.BuildUI;
+begin
+  // Entire UI is created in code - no .fmx (see Docs/FMX-Pseudo-Console.md).
+  FStatus := TLabel.Create(Self);
+  FStatus.Parent := Self;
+  FStatus.Align := TAlignLayout.Top;
+  FStatus.Height := 28;
+  FStatus.Text := 'Ready';
+
+  FRunAgain := TButton.Create(Self);
+  FRunAgain.Parent := Self;
+  FRunAgain.Align := TAlignLayout.Top;
+  FRunAgain.Height := 36;
+  FRunAgain.Text := 'Run again';
+  FRunAgain.OnClick := HandleRunAgainClick;
+
+  FMemo := TMemo.Create(Self);
+  FMemo.Parent := Self;
+  FMemo.Align := TAlignLayout.Client;
+  FMemo.ReadOnly := True;
+end;
+
+procedure TDUnitXFMXConsoleHost.HandleShow(Sender : TObject);
+begin
+  if not FHasAutoRun then
+  begin
+    FHasAutoRun := True;
+    RunTests;
+  end;
+end;
+
+procedure TDUnitXFMXConsoleHost.HandleRunAgainClick(Sender : TObject);
+begin
+  RunTests;
+end;
+
+procedure TDUnitXFMXConsoleHost.RunTests;
+var
+  runner : ITestRunner;
+  results : IRunResults;
+  logger : ITestLogger;
+begin
+  if FRunning then
+    Exit;
+  FRunning := True;
+  FRunAgain.Enabled := False;
+  try
+    try
+      FMemo.Lines.Clear;
+      FStatus.Text := 'Running...';
+
+      runner := TDUnitX.CreateRunner;
+      runner.UseRTTI := True;
+      runner.FailsOnNoAsserts := False;
+
+      logger := TDUnitXFMXConsoleLogger.Create(FMemo.Lines, False);
+      runner.AddLogger(logger);
+
+      results := runner.Execute;
+
+      if results.AllPassed then
+        FStatus.Text := Format('Done - all passed (%d)', [results.PassCount])
+      else
+        FStatus.Text := Format('Done - failed: %d  errored: %d  ignored: %d  passed: %d',
+          [results.FailureCount, results.ErrorCount, results.IgnoredCount, results.PassCount]);
+    except
+      on E : Exception do
+      begin
+        FMemo.Lines.Add(E.ClassName + ': ' + E.Message);
+        FStatus.Text := 'Error - ' + E.Message;
+      end;
+    end;
+  finally
+    FRunning := False;
+    FRunAgain.Enabled := True;
+  end;
+end;
+
+procedure Run;
+var
+  host : TDUnitXFMXConsoleHost;
+begin
+  TDUnitX.CheckCommandLine;
+
+  Application.Initialize;
+  host := TDUnitXFMXConsoleHost.CreateNew(Application);
+  Application.MainForm := host;
+  host.Show;
+  Application.Run;
+end;
+
+end.

--- a/Source/DUnitX.Loggers.Console.FMX.pas
+++ b/Source/DUnitX.Loggers.Console.FMX.pas
@@ -33,20 +33,26 @@ uses
 {$IFDEF USE_NS}
   System.Classes,
   System.SysUtils,
+  System.UITypes,
   FMX.Types,
+  FMX.Graphics,
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
   FMX.Memo,
+  FMX.Objects,
   FMX.Controls.Presentation,
 {$ELSE}
   Classes,
   SysUtils,
+  UITypes,
   FMX.Types,
+  FMX.Graphics,
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
   FMX.Memo,
+  FMX.Objects,
 {$ENDIF}
   DUnitX.TestFramework,
   DUnitX.ResStrs;
@@ -100,11 +106,13 @@ type
   TDUnitXFMXConsoleHost = class(TForm)
   private
     FStatus : TLabel;
-    FRunAgain : TButton;
+    FRunAgain : TLabel;
     FMemo : TMemo;
     FHasAutoRun : Boolean;
     FRunning : Boolean;
+    procedure ApplyConsoleText(const ATextSettings : TTextSettings);
     procedure BuildUI;
+    procedure HandleMemoApplyStyleLookup(Sender : TObject);
     procedure HandleShow(Sender : TObject);
     procedure HandleRunAgainClick(Sender : TObject);
     procedure RunTests;
@@ -442,26 +450,98 @@ begin
   OnShow := HandleShow;
 end;
 
+function ConsoleFontFamily : string;
+begin
+{$IFDEF MSWINDOWS}
+  Result := 'Consolas';
+{$ELSE}
+{$IFDEF ANDROID}
+  Result := 'monospace';
+{$ELSE}
+{$IFDEF IOS}
+  Result := 'Menlo';
+{$ELSE}
+  Result := 'Courier New';
+{$ENDIF}
+{$ENDIF}
+{$ENDIF}
+end;
+
+procedure TDUnitXFMXConsoleHost.ApplyConsoleText(const ATextSettings : TTextSettings);
+begin
+  ATextSettings.Font.Family := ConsoleFontFamily;
+  ATextSettings.Font.Size := 12;
+  ATextSettings.FontColor := $FFD4D4D4;
+end;
+
+procedure TDUnitXFMXConsoleHost.HandleMemoApplyStyleLookup(Sender : TObject);
+const
+  cConsoleBg = $FF0C0C0C;
+var
+  LBackground : TFmxObject;
+  LRect : TRectangle;
+  i : Integer;
+begin
+  // Default FMX memo skin is TActiveStyleObject (bitmap), not TRectangle.
+  LBackground := FMemo.FindStyleResource('background');
+  if LBackground = nil then
+    Exit;
+  for i := 0 to LBackground.ChildrenCount - 1 do
+    if LBackground.Children[i].StyleName = 'consolebg' then
+      Exit;
+
+  LRect := TRectangle.Create(LBackground);
+  LRect.StyleName := 'consolebg';
+  LRect.Parent := LBackground;
+  LRect.Align := TAlignLayout.Contents;
+  LRect.HitTest := False;
+  LRect.Stroke.Kind := TBrushKind.None;
+  LRect.Fill.Kind := TBrushKind.Solid;
+  LRect.Fill.Color := cConsoleBg;
+  LRect.SendToBack;
+end;
+
 procedure TDUnitXFMXConsoleHost.BuildUI;
 begin
   // Entire UI is created in code - no .fmx (see Docs/FMX-Pseudo-Console.md).
+  Fill.Kind := TBrushKind.Solid;
+  Fill.Color := $FF0C0C0C;
+
   FStatus := TLabel.Create(Self);
   FStatus.Parent := Self;
   FStatus.Align := TAlignLayout.Top;
   FStatus.Height := 28;
+  FStatus.Margins.Left := 8;
+  FStatus.Margins.Right := 8;
+  FStatus.StyledSettings := [];
+  ApplyConsoleText(FStatus.TextSettings);
   FStatus.Text := 'Ready';
 
-  FRunAgain := TButton.Create(Self);
+  FRunAgain := TLabel.Create(Self);
   FRunAgain.Parent := Self;
   FRunAgain.Align := TAlignLayout.Top;
-  FRunAgain.Height := 36;
-  FRunAgain.Text := 'Run again';
+  FRunAgain.Height := 24;
+  FRunAgain.Margins.Left := 8;
+  FRunAgain.Margins.Right := 8;
+  FRunAgain.Margins.Bottom := 4;
+  FRunAgain.HitTest := True;
+  FRunAgain.Cursor := crHandPoint;
+  FRunAgain.StyledSettings := [];
+  ApplyConsoleText(FRunAgain.TextSettings);
+  FRunAgain.Text := '> Run again';
   FRunAgain.OnClick := HandleRunAgainClick;
 
   FMemo := TMemo.Create(Self);
+  FMemo.OnApplyStyleLookup := HandleMemoApplyStyleLookup;
   FMemo.Parent := Self;
   FMemo.Align := TAlignLayout.Client;
+  FMemo.Margins.Left := 8;
+  FMemo.Margins.Right := 8;
+  FMemo.Margins.Bottom := 8;
   FMemo.ReadOnly := True;
+  FMemo.WordWrap := False;
+  FMemo.StyledSettings := [];
+  ApplyConsoleText(FMemo.TextSettings);
 end;
 
 procedure TDUnitXFMXConsoleHost.HandleShow(Sender : TObject);
@@ -488,6 +568,7 @@ begin
     Exit;
   FRunning := True;
   FRunAgain.Enabled := False;
+  FRunAgain.Opacity := 0.45;
   try
     try
       FMemo.Lines.Clear;
@@ -517,6 +598,7 @@ begin
   finally
     FRunning := False;
     FRunAgain.Enabled := True;
+    FRunAgain.Opacity := 1;
   end;
 end;
 

--- a/Source/DUnitX.Loggers.Console.FMX.pas
+++ b/Source/DUnitX.Loggers.Console.FMX.pas
@@ -111,11 +111,13 @@ type
     FMemo : TMemo;
     FHasAutoRun : Boolean;
     FRunning : Boolean;
+    FRunCount : Integer;
     procedure ApplyConsoleText(const ATextSettings : TTextSettings);
     procedure BuildUI;
     procedure HandleMemoApplyStyleLookup(Sender : TObject);
     procedure HandleShow(Sender : TObject);
-    procedure HandleRunAgainClick(Sender : TObject);
+    procedure HandleRunAgainMouseDown(Sender : TObject; Button : TMouseButton;
+      Shift : TShiftState; X, Y : Single);
     procedure RunTests;
   public
     constructor CreateNew(AOwner : TComponent; Dummy : NativeInt = 0); override;
@@ -447,6 +449,7 @@ begin
   Height := 500;
   FHasAutoRun := False;
   FRunning := False;
+  FRunCount := 0;
   BuildUI;
   OnShow := HandleShow;
 end;
@@ -533,7 +536,7 @@ begin
   FRunAgain.HitTest := True;
   FRunAgain.AutoCapture := True;
   FRunAgain.Cursor := crHandPoint;
-  FRunAgain.OnClick := HandleRunAgainClick;
+  FRunAgain.OnMouseDown := HandleRunAgainMouseDown;
 
   FRunAgainLabel := TText.Create(FRunAgain);
   FRunAgainLabel.Parent := FRunAgain;
@@ -568,9 +571,11 @@ begin
   end;
 end;
 
-procedure TDUnitXFMXConsoleHost.HandleRunAgainClick(Sender : TObject);
+procedure TDUnitXFMXConsoleHost.HandleRunAgainMouseDown(Sender : TObject;
+  Button : TMouseButton; Shift : TShiftState; X, Y : Single);
 begin
-  RunTests;
+  if Button = TMouseButton.mbLeft then
+    RunTests;
 end;
 
 procedure TDUnitXFMXConsoleHost.RunTests;
@@ -586,8 +591,12 @@ begin
   FRunAgain.Opacity := 0.45;
   try
     try
+      Inc(FRunCount);
       FMemo.Lines.Clear;
-      FStatus.Text := 'Running...';
+      FStatus.Text := Format('Running...  (run %d)', [FRunCount]);
+      FStatus.Repaint;
+      FMemo.Repaint;
+      Application.ProcessMessages;
 
       runner := TDUnitX.CreateRunner;
       runner.UseRTTI := True;
@@ -599,10 +608,10 @@ begin
       results := runner.Execute;
 
       if results.AllPassed then
-        FStatus.Text := Format('Done - all passed (%d)', [results.PassCount])
+        FStatus.Text := Format('Done - all passed (%d)  · run %d', [results.PassCount, FRunCount])
       else
-        FStatus.Text := Format('Done - failed: %d  errored: %d  ignored: %d  passed: %d',
-          [results.FailureCount, results.ErrorCount, results.IgnoredCount, results.PassCount]);
+        FStatus.Text := Format('Done - failed: %d  errored: %d  ignored: %d  passed: %d  · run %d',
+          [results.FailureCount, results.ErrorCount, results.IgnoredCount, results.PassCount, FRunCount]);
     except
       on E : Exception do
       begin

--- a/Source/DUnitX.Loggers.Console.FMX.pas
+++ b/Source/DUnitX.Loggers.Console.FMX.pas
@@ -39,6 +39,7 @@ uses
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
+  FMX.Layouts,
   FMX.Memo,
   FMX.Objects,
   FMX.Controls.Presentation,
@@ -51,6 +52,7 @@ uses
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
+  FMX.Layouts,
   FMX.Memo,
   FMX.Objects,
 {$ENDIF}
@@ -106,7 +108,8 @@ type
   TDUnitXFMXConsoleHost = class(TForm)
   private
     FStatus : TLabel;
-    FRunAgain : TLabel;
+    FRunAgain : TLayout;
+    FRunAgainLabel : TLabel;
     FMemo : TMemo;
     FHasAutoRun : Boolean;
     FRunning : Boolean;
@@ -517,7 +520,9 @@ begin
   ApplyConsoleText(FStatus.TextSettings);
   FStatus.Text := 'Ready';
 
-  FRunAgain := TLabel.Create(Self);
+  // TLabel's styled TText eats mouse hits and does not bubble OnClick.
+  // A layout is the hit target; the label is display-only.
+  FRunAgain := TLayout.Create(Self);
   FRunAgain.Parent := Self;
   FRunAgain.Align := TAlignLayout.Top;
   FRunAgain.Height := 24;
@@ -526,10 +531,15 @@ begin
   FRunAgain.Margins.Bottom := 4;
   FRunAgain.HitTest := True;
   FRunAgain.Cursor := crHandPoint;
-  FRunAgain.StyledSettings := [];
-  ApplyConsoleText(FRunAgain.TextSettings);
-  FRunAgain.Text := '> Run again';
   FRunAgain.OnClick := HandleRunAgainClick;
+
+  FRunAgainLabel := TLabel.Create(FRunAgain);
+  FRunAgainLabel.Parent := FRunAgain;
+  FRunAgainLabel.Align := TAlignLayout.Client;
+  FRunAgainLabel.HitTest := False;
+  FRunAgainLabel.StyledSettings := [];
+  ApplyConsoleText(FRunAgainLabel.TextSettings);
+  FRunAgainLabel.Text := '> Run again';
 
   FMemo := TMemo.Create(Self);
   FMemo.OnApplyStyleLookup := HandleMemoApplyStyleLookup;

--- a/Source/DUnitX.Loggers.Console.FMX.pas
+++ b/Source/DUnitX.Loggers.Console.FMX.pas
@@ -39,7 +39,6 @@ uses
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
-  FMX.Layouts,
   FMX.Memo,
   FMX.Objects,
   FMX.Controls.Presentation,
@@ -52,7 +51,6 @@ uses
   FMX.Controls,
   FMX.Forms,
   FMX.StdCtrls,
-  FMX.Layouts,
   FMX.Memo,
   FMX.Objects,
 {$ENDIF}
@@ -108,8 +106,8 @@ type
   TDUnitXFMXConsoleHost = class(TForm)
   private
     FStatus : TLabel;
-    FRunAgain : TLayout;
-    FRunAgainLabel : TLabel;
+    FRunAgain : TRectangle;
+    FRunAgainLabel : TText;
     FMemo : TMemo;
     FHasAutoRun : Boolean;
     FRunning : Boolean;
@@ -520,25 +518,32 @@ begin
   ApplyConsoleText(FStatus.TextSettings);
   FStatus.Text := 'Ready';
 
-  // TLabel's styled TText eats mouse hits and does not bubble OnClick.
-  // A layout is the hit target; the label is display-only.
-  FRunAgain := TLayout.Create(Self);
+  // TLabel/TLayout: styled TText still has HitTest=True and swallows the click.
+  // TRectangle + primitive TText (HitTest=False) is a real mouse target.
+  FRunAgain := TRectangle.Create(Self);
   FRunAgain.Parent := Self;
   FRunAgain.Align := TAlignLayout.Top;
   FRunAgain.Height := 24;
   FRunAgain.Margins.Left := 8;
   FRunAgain.Margins.Right := 8;
   FRunAgain.Margins.Bottom := 4;
+  FRunAgain.Fill.Kind := TBrushKind.Solid;
+  FRunAgain.Fill.Color := $FF0C0C0C;
+  FRunAgain.Stroke.Kind := TBrushKind.None;
   FRunAgain.HitTest := True;
+  FRunAgain.AutoCapture := True;
   FRunAgain.Cursor := crHandPoint;
   FRunAgain.OnClick := HandleRunAgainClick;
 
-  FRunAgainLabel := TLabel.Create(FRunAgain);
+  FRunAgainLabel := TText.Create(FRunAgain);
   FRunAgainLabel.Parent := FRunAgain;
   FRunAgainLabel.Align := TAlignLayout.Client;
   FRunAgainLabel.HitTest := False;
-  FRunAgainLabel.StyledSettings := [];
-  ApplyConsoleText(FRunAgainLabel.TextSettings);
+  FRunAgainLabel.HorzTextAlign := TTextAlign.Leading;
+  FRunAgainLabel.VertTextAlign := TTextAlign.Center;
+  FRunAgainLabel.TextSettings.Font.Family := ConsoleFontFamily;
+  FRunAgainLabel.TextSettings.Font.Size := 12;
+  FRunAgainLabel.TextSettings.FontColor := $FFD4D4D4;
   FRunAgainLabel.Text := '> Run again';
 
   FMemo := TMemo.Create(Self);


### PR DESCRIPTION
Hi Vincent,

Hope you’re well — a small one from me, with a bit of a story attached.

Android and iOS still have no real console (RSP-17631, and the old “run on Android” thread). I needed the same DUnitX suite on a device and something that *looks* like the console logger, without dragging in the FMX GUI explorer (and without touching MobileGUI / GUIX / VCL, which I know you’d rather leave alone).

This adds:

- `TDUnitXFMXConsoleLogger` — same messages as `TDUnitXConsoleLogger`, but into a `TStrings` / `TMemo` (no `WriteLn`, no I/O 105).
- `TDUnitXFMXConsoleHost` + `Run` — a tiny host built with `TForm.CreateNew` (no `.fmx`). I went that way on purpose: FMX designer files have been painful across versions, and I didn’t want to add another one for you to babysit.
- One modern example (`Examples/DUnitXConsoleFMX`) — Win32/Win64, Android, iOSDevice64 / iOSSimARM64. Not a version matrix.

Typical use:

```delphi
uses
  DUnitX.Loggers.Console.FMX;
begin
  DUnitX.Loggers.Console.FMX.Run;
end.
```

Or attach the logger to your own memo.

Verified here on Delphi 13.1: Win32 run of the example (including “Run again”), and an iOSDevice64 compile. Android compiles on the Pascal side; linking needs a local NDK, which this machine didn’t have.

Happy to tweak anything — especially if you’d rather the host live somewhere else or drop the example.

Cheers,
Olaf