### PR TITLE
Parse ISO-8601 TestCase DateTimes that carry a timezone suffix

### DIFF
--- a/Source/DUnitX.Utils.pas
+++ b/Source/DUnitX.Utils.pas
@@ -1127,6 +1127,36 @@ begin
   Result := True;
 end;
 
+function StripIso8601TimeZone(const ASource : string) : string;
+var
+  i : Integer;
+  len : Integer;
+begin
+  // TestCase values such as '1988-10-21T17:44:23.456Z' / '+02:30' are wall-clock
+  // timestamps; the suffix is not applied. StrToDateTimeDef rejects those suffixes
+  // and returns 0 (30.12.1899), which is what the ISO-8601 verbose tests hit.
+  Result := ASource;
+  len := Length(Result);
+  if len = 0 then
+    Exit;
+
+  if CharInSet(Result[len], ['Z', 'z']) then
+  begin
+    SetLength(Result, len - 1);
+    Exit;
+  end;
+
+  // yyyy-mm-dd is 10 characters; any later '+' or '-' is a timezone offset.
+  for i := 11 to len do
+  begin
+    if CharInSet(Result[i], ['+', '-']) then
+    begin
+      SetLength(Result, i - 1);
+      Exit;
+    end;
+  end;
+end;
+
 function Str2DateTimeValue(const ASource : string) : TValue;
 var
   dateTime : TDateTime;
@@ -1140,7 +1170,7 @@ begin
     iso8601.ShortTimeFormat := 'hh:nn:ss\.nnn';
     iso8601.TimeSeparator := ':';
 
-    dateTime := StrToDateTimeDef(ASource, 0, iso8601);
+    dateTime := StrToDateTimeDef(StripIso8601TimeZone(ASource), 0, iso8601);
   end;
 
   Result := TValue.From<TDateTime>(dateTime);

--- a/Tests/DUnitX.Tests.Utils.pas
+++ b/Tests/DUnitX.Tests.Utils.pas
@@ -83,13 +83,9 @@ type
     [TestCase('EN-GB local format, 12 h, verbose', 'EN-GB,22/06/2020 06:36:00 pm')]
     [TestCase('DE local format, verbose', 'DE,22.06.2020 18:36:00.000')]
     [TestCase('DE local format, short', 'DE,22.6.20 18:36')]
-{$IFDEF DELPHI_X8_UP}
-    [TestCase('EN-US iso 8601 format', 'EN-US,2020-06-22 18:36:00')]
-    [TestCase('EN-US iso 8601 format, verbose', 'EN-US,2020-06-22T18:36:00.000Z')]
-    [TestCase('EN-GB iso8601 format', 'EN-GB,2020-06-22 18:36')]
-    [TestCase('EN-GB iso8601 format, verbose', 'EN-GB,2020-06-22T18:36:00+00')]
-    [TestCase('DE iso8601 format', 'DE,2020-06-22 18:36:00')]
-{$ENDIF}
+    // ISO-8601 belongs on TestDateTimeConversion (TValue.TryConvert).
+    // RTL StrToDateTime does not parse those strings (Delphi 13.1, EN-US/EN-GB/DE).
+    // The previous {$IFDEF DELPHI_X8_UP} never compiled (DUnitX.inc defines DELPHI_XE8_UP).
     procedure TestDateTimeConversion2(const locale : string; const text : string);
 
     [Test]


### PR DESCRIPTION
Hi Vincent,

Tiny, unrelated follow-up from a Delphi 13.1 run — not part of the FMX work, so I split it off.

`Str2DateTimeValue` already falls back to ISO-ish `TFormatSettings` when `TryStrToDateTime` fails. That path accepts the `T` separator, but **rejects** a trailing `Z` / `+00` / `+02:30` / `+0230` and returns `0` (`30.12.1899`). Five tests then fail with `SameDateTime` against that zero date:

- `TestDateTimeArgument` — the Z / offset cases
- `TestDateTimeConversion` — the two “verbose” ISO cases

The assertions compare **wall-clock digits**, they don’t convert to UTC, so `ISO8601ToDate` would be the wrong fix (it would shift `+02:30`). I just strip the suffix and keep the existing fallback.

While I was there: `TestDateTimeConversion2` (plain RTL `StrToDateTime`) had ISO cases behind `{$IFDEF DELPHI_X8_UP}`. That symbol is never defined — `DUnitX.inc` has `DELPHI_XE8_UP`. Enabling it on 13.1 makes all five of those cases raise `EConvertError`. Coverage for those strings already lives on `TestDateTimeConversion` via `TValue.TryConvert`, so I dropped the dead cases and left a short comment.

Happy to change the comment or put the cases back behind the correct define if you’d rather keep them ignored.

Cheers,
Olaf