### PR TITLE
Use FastMM4.GetMemoryManagerUsageSummary for leak accounting

### DIFF
--- a/Source/DUnitX.MemoryLeakMonitor.FastMM4.pas
+++ b/Source/DUnitX.MemoryLeakMonitor.FastMM4.pas
@@ -42,7 +42,10 @@ implementation
 
 uses
   DUnitX.MemoryLeakMonitor.Default,
-  DUnitX.ServiceLocator;
+  DUnitX.ServiceLocator
+{$IFDEF USE_FASTMM4_LEAK_MONITOR}
+  , FastMM4
+{$ENDIF};
 
 type
   TDUnitXFastMM4MemoryLeakMonitor = class(TInterfacedObject, IMemoryLeakMonitor)
@@ -71,6 +74,19 @@ type
   { TDUnitXFastMM4MemoryLeakMonitor }
 
 function TDUnitXFastMM4MemoryLeakMonitor.GetMemoryAllocated : Int64;
+{$IFDEF USE_FASTMM4_LEAK_MONITOR}
+var
+  LSummary : TMemoryManagerUsageSummary;
+begin
+  { System.GetMemoryManagerState walks the RTL's bundled FastMM, not a
+    FastMM4.pas installed as the first unit (the leak-monitor setup). Those
+    structures stay empty / stale, so the old SmallBlockTypeStates loop
+    reported 0 or nonsense. FastMM4.GetMemoryManagerUsageSummary reads
+    FastMM4's own block lists. }
+  GetMemoryManagerUsageSummary(LSummary);
+  Result := Int64(LSummary.AllocatedBytes);
+end;
+{$ELSE}
 var
   st : TMemoryManagerState;
   sb : TSmallBlockTypeState;
@@ -84,6 +100,7 @@ begin
     Result := Result + Int64(sb.UseableBlockSize * sb.AllocatedBlockCount);
   end;
 end;
+{$ENDIF}
 
 procedure TDUnitXFastMM4MemoryLeakMonitor.PostSetUp;
 begin

--- a/Source/DUnitX.MemoryLeaks.inc
+++ b/Source/DUnitX.MemoryLeaks.inc
@@ -27,8 +27,9 @@
 
 
 // Uncomment to use FastMM4 Memory Leak Tracking.
-//NOTE : Memory leak tracking does not work very well at the moment, as it's
-//reporting leaks when logging information during tests (calls to .Status etc).
+// FastMM4.pas must be the first unit in the .dpr (see the New Test Project wizard).
+// NOTE: Leak tracking can still report "leaks" from logging during tests
+// (calls to .Status etc).
 {.$DEFINE USE_FASTMM4_LEAK_MONITOR}
 
 


### PR DESCRIPTION
Hi Vincent,

Another small one from the Delphi 13.1 pass — this time FastMM4 leak accounting.

**What was actually wrong**

`DUnitX.MemoryLeakMonitor.FastMM4` called `System.GetMemoryManagerState` and summed medium/large plus `UseableBlockSize * AllocatedBlockCount` over `SmallBlockTypeStates`. That looks right on paper, and it *is* the same formula FastMM4 uses internally — but `System.GetMemoryManagerState` walks the **RTL’s bundled FastMM**, not a `FastMM4.pas` you put first in the .dpr (which is exactly the setup the New Test Project wizard generates). There is no MM callback for that; `TMemoryManagerEx` never exposes it.

With `FastMM4.pas` as the first unit I measured `AllocMem(4096)`:

- RTL `GetMemoryManagerState`: delta **0**
- `FastMM4.GetMemoryManagerUsageSummary`: delta **4140**

So the monitor was effectively blind. On top of that the array lengths don’t even match (RTL Win32 `NumSmallBlockTypes = 55`, FastMM4 default **56**), so a `for sb in st.SmallBlockTypeStates` is the wrong record even if you had the right heap.

**What this PR does**

When `USE_FASTMM4_LEAK_MONITOR` is on, call `FastMM4.GetMemoryManagerUsageSummary` and use `AllocatedBytes` — FastMM4’s own lists, same idea as FastMM5 already does with `FastMM_GetUsageSummary`. The define in `DUnitX.MemoryLeaks.inc` stays **off**; I’m not flipping that by accident again.

You’ll see a bit more code than a one-line swap: the old RTL path stays behind `{$ELSE}` so this unit still compiles in the D2010/XE test projects that reference it **without** FastMM4 on the search path. A bit of ifdef noise, but it keeps leak numbers honest when someone actually turns the monitor on — which I think is worth it.

I haven’t moved this over to FastMM5 in the open tree. FastMM5’s licence is awkward for anything I ship or share; I only use it in closed repos. FastMM4 remains the practical option here, and this just makes that path report real allocations.

Happy to drop the `{$ELSE}` path if you’d rather require FastMM4 whenever this unit is compiled.

Cheers,
Olaf